### PR TITLE
build(compose): Update compose version to 5.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # .github/workflows/build.yml
 # CI/CD pipeline for Compose Manager plugin
-# 
+#
 # This workflow automates the release process:
 # - Builds TXZ package using Docker (Slackware)
 # - Calculates MD5 for integrity verification
@@ -16,22 +16,21 @@ name: Build & Release Plugin
 on:
   push:
     tags:
-      - 'v20[0-9][0-9].[0-9][0-9].[0-9][0-9]*'
+      - "v20[0-9][0-9].[0-9][0-9].[0-9][0-9]*"
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., 2026.02.01) - leave empty for test build'
+        description: "Version to build (e.g., 2026.02.01) - leave empty for test build"
         required: false
-        default: ''
+        default: ""
 
 permissions:
   contents: write
 
 env:
   PLUGIN_NAME: compose.manager
-  COMPOSE_VERSION: '2.40.3'
-  COMPOSE_SWITCH_VERSION: '1.0.5'
-  ACE_VERSION: '1.4.14'
+  COMPOSE_VERSION: "5.0.2"
+  ACE_VERSION: "1.4.14"
 
 jobs:
   build:
@@ -39,7 +38,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
       md5: ${{ steps.hash.outputs.MD5 }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -65,23 +64,22 @@ jobs:
       - name: Build TXZ package in Docker
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          
+
           # Set executable permissions
           chmod +x ./build_in_docker.sh
           chmod +x ./source/pkg_build.sh
-          
+
           # Build using the Slackware Docker container
           docker run --rm --tmpfs /tmp \
             -v $PWD/archive:/mnt/output:rw \
             -v $PWD/source:/mnt/source:ro \
             -e TZ="America/New_York" \
             -e COMPOSE_VERSION=${{ env.COMPOSE_VERSION }} \
-            -e COMPOSE_SWITCH_VERSION=${{ env.COMPOSE_SWITCH_VERSION }} \
             -e ACE_VERSION=${{ env.ACE_VERSION }} \
             -e OUTPUT_FOLDER="/mnt/output" \
             -e PKG_VERSION="${VERSION}" \
             vbatts/slackware:latest /mnt/source/pkg_build.sh
-          
+
           # Verify package was created
           ls -la ./archive/
           if [[ ! -f "./archive/${{ env.PLUGIN_NAME }}-package-${VERSION}.txz" ]]; then
@@ -94,7 +92,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
           PACKAGE="./archive/${{ env.PLUGIN_NAME }}-package-${VERSION}.txz"
-          
+
           MD5=$(md5sum "$PACKAGE" | cut -d' ' -f1)
           echo "MD5=${MD5}" >> $GITHUB_OUTPUT
           echo "Package MD5: ${MD5}"
@@ -112,7 +110,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -130,28 +128,28 @@ jobs:
         id: notes
         run: |
           VERSION="${{ needs.build.outputs.version }}"
-          
+
           # Read component versions from release_info
           if [[ -f artifacts/release_info ]]; then
             COMPONENTS=$(cat artifacts/release_info)
           else
             COMPONENTS="Compose v${{ env.COMPOSE_VERSION }}"
           fi
-          
+
           # Create release body
           cat > release_body.md << EOF
           ## Compose Manager v${VERSION}
-          
+
           ### Installation
-          
+
           **Via Plugin Manager:**
           \`\`\`
           https://raw.githubusercontent.com/${{ github.repository }}/main/${{ env.PLUGIN_NAME }}.plg
           \`\`\`
-          
+
           ### Package Details
           - **MD5:** \`${{ needs.build.outputs.md5 }}\`
-          
+
           ### Components
           ${COMPONENTS}
           EOF
@@ -173,20 +171,20 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           MD5="${{ needs.build.outputs.md5 }}"
-          
+
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           # Update version and MD5 in PLG
           sed -i \
             -e "s|<!ENTITY version.*\".*\"|<!ENTITY version     \"${VERSION}\"|" \
             -e "s|<!ENTITY packageMD5.*\".*\"|<!ENTITY packageMD5  \"${MD5}\"|" \
             ${{ env.PLUGIN_NAME }}.plg
-          
+
           echo "Updated PLG file:"
           head -20 ${{ env.PLUGIN_NAME }}.plg
-          
+
           # Commit and push
           git add ${{ env.PLUGIN_NAME }}.plg
           git commit -m "Release v${VERSION}" || echo "No changes to commit"

--- a/build.ps1
+++ b/build.ps1
@@ -72,7 +72,6 @@ $dockerArgs = @(
     "-v", "${SourcePath}:/mnt/source:ro"
     "-e", "TZ=America/New_York"
     "-e", "COMPOSE_VERSION=$ComposeVersion"
-    "-e", "COMPOSE_SWITCH_VERSION=$ComposeSwitchVersion"
     "-e", "ACE_VERSION=$AceVersion"
     "-e", "OUTPUT_FOLDER=/mnt/output"
     "-e", "PKG_VERSION=$Version"
@@ -91,12 +90,12 @@ $PackagePath = Join-Path $OutputPath $PackageName
 if (Test-Path $PackagePath) {
     # Calculate MD5
     $md5 = (Get-FileHash -Path $PackagePath -Algorithm MD5).Hash.ToLower()
-    
+
     Write-Host ""
     Write-Host "Build successful!" -ForegroundColor Green
     Write-Host "  Package: $PackagePath" -ForegroundColor Cyan
     Write-Host "  MD5: $md5" -ForegroundColor Cyan
-    
+
     # Return build info for use by release script
     return @{
         Version = $Version

--- a/build_in_docker.sh
+++ b/build_in_docker.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-[ -z "$COMPOSE_VERSION" ] && COMPOSE_VERSION=2.40.3
-[ -z "$COMPOSE_SWITCH_VERSION" ] && COMPOSE_SWITCH_VERSION=1.0.5
+[ -z "$COMPOSE_VERSION" ] && COMPOSE_VERSION=5.0.2
 [ -z "$ACE_VERSION" ] && ACE_VERSION=1.43.5
-docker run --rm --tmpfs /tmp -v $PWD/archive:/mnt/output:rw -e TZ="America/New_York" -e COMPOSE_VERSION=$COMPOSE_VERSION -e COMPOSE_SWITCH_VERSION=$COMPOSE_SWITCH_VERSION -e ACE_VERSION=$ACE_VERSION -e OUTPUT_FOLDER="/mnt/output" -v $PWD/source:/mnt/source:ro vbatts/slackware:latest /mnt/source/pkg_build.sh $UI_VERSION_LETTER
+docker run --rm --tmpfs /tmp \
+    -v $PWD/archive:/mnt/output:rw \
+    -e TZ="America/New_York" \
+    -e COMPOSE_VERSION=$COMPOSE_VERSION \
+    -e ACE_VERSION=$ACE_VERSION \
+    -e OUTPUT_FOLDER="/mnt/output" \
+    -v $PWD/source:/mnt/source:ro \
+    vbatts/slackware:latest \
+    /mnt/source/pkg_build.sh $UI_VERSION_LETTER

--- a/source/pkg_build.sh
+++ b/source/pkg_build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 [ -z "$OUTPUT_FOLDER" ] && echo "Output Folder not set" && exit 1
 [ -z "$COMPOSE_VERSION" ] && echo "Compose Version not set" && exit 2
-[ -z "$COMPOSE_SWITCH_VERSION" ] && echo "Compose Switch Version not set" && exit 3
 [ -z "$ACE_VERSION" ] && echo "ACE Version not set" && exit 4
 [ -z "$PKG_VERSION" ] && echo "Package Version not set" && exit 5
 tmpdir=/tmp/tmp.$(( $RANDOM * 19318203981230 + 40 ))
@@ -34,13 +33,6 @@ mkdir -p $tmpdir/usr/lib/docker/cli-plugins/
 cp docker-compose-linux-x86_64 $tmpdir/usr/lib/docker/cli-plugins/docker-compose
 chmod -R +x $tmpdir/usr/lib/docker/cli-plugins/
 rm docker-compose-linux-x86_64
-
-#Install compose switch
-wget --no-check-certificate  https://github.com/docker/compose-switch/releases/download/v${COMPOSE_SWITCH_VERSION}/docker-compose-linux-amd64 
-mkdir -p $tmpdir/usr/local/bin
-cp docker-compose-linux-amd64 $tmpdir/usr/local/bin/docker-compose
-chmod +x $tmpdir/usr/local/bin/docker-compose
-rm docker-compose-linux-amd64
 
 #Install Ace Editor
 mkdir -p $tmpdir/usr/local/emhttp/plugins/compose.manager/javascript/ace/
@@ -84,7 +76,6 @@ MD5=`md5sum $OUTPUT_FOLDER/compose.manager-package-${version}.txz`
 echo "MD5: $MD5"
 
 echo "Compose v${COMPOSE_VERSION}" >> $OUTPUT_FOLDER/release_info
-echo "Compose Switch v${COMPOSE_SWITCH_VERSION}" >> $OUTPUT_FOLDER/release_info
 echo "Ace v${ACE_VERSION}" >> $OUTPUT_FOLDER/release_info
 echo "" >> $OUTPUT_FOLDER/release_info
 echo "MD5: $(echo $MD5 | head -n1 | awk '{print $1;}')" >> $OUTPUT_FOLDER/release_info


### PR DESCRIPTION
Title: Update compose version to 5.0.2

**What changed**
- Update Compose version from 2.40.3 to 5.0.2
- Removed Compose Switcher

**Related issues**
Closes #39

**Checklist**
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation (docs/, README, or plugin docs)
- [x] Linted/formatted the code
- [ ] Verified on Unraid or CI