### PR TITLE
Fix: loading when expanded by default

### DIFF
--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -333,10 +333,12 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
             $('#compose_stacks').removeClass('cm-advanced-view');
         }
 
-        // Seed expandedStacks from any rows rendered expanded server-side
+        // Seed expandedStacks from any rows rendered expanded server-side and kick off their loads
         $('.stack-details-row:visible').each(function() {
             var stackId = this.id.replace('details-row-', '');
             expandedStacks[stackId] = true;
+            var project = $('#stack-row-' + stackId).data('project');
+            loadStackContainerDetails(stackId, project);
         });
 
         // Load saved update status after list is loaded


### PR DESCRIPTION
Stacks wouldn't always load properly when expanded by default. They would just say 'Loading containers...' without actually loading.

This kicks off the call to load them properly when initially expanded.