### PR TITLE
fix: Container names wrong when dashes used

### DIFF
--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -2380,7 +2380,7 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
 
             containers.forEach(function(container, index) {
                 var containerName = container.Name || container.Service || 'Unknown';
-                var shortName = containerName.replace(/^[^-]+-/, '');
+                var shortName = container.Service || containerName.replace(/^[^-]+-/, '');
                 var image = container.Image || '';
                 var imageParts = image.split(':');
                 var imageName = imageParts[0].split('/').pop();
@@ -3666,7 +3666,7 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
 
         containers.forEach(function(container, idx) {
             var containerName = container.Name || container.Service || 'Unknown';
-            var shortName = containerName.replace(/^[^-]+-/, ''); // Remove project prefix
+            var shortName = container.Service || containerName.replace(/^[^-]+-/, ''); // Prefer service name; fall back to stripping project prefix
             var image = container.Image || '';
 
             // Parse image - handle docker.io/ prefix and @sha256: digest


### PR DESCRIPTION
If the stack or container name have a dash in them, the name will be displayed incorrectly, because of the way it tries to split out the stack and name from the default generated container names.

This prefers getting the service name for each container instead, reverting to the original behaviour if that isn't set.