### PR TITLE
Add CPU and MEM to the advanced view mode

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -14,7 +14,7 @@
 	Generate a development build with timestamp: YYYY.MM.DD.HHmm
 
 .PARAMETER RemoteHost
-	Remote hostname or IP.
+	Remote hostname(s) or IP(s). Accepts a single value or a comma-separated list.
 
 .PARAMETER User
 	SSH username.
@@ -45,6 +45,9 @@
 	./deploy.ps1 -Dev -RemoteHost "saturn"
 
 .EXAMPLE
+	./deploy.ps1 -Dev -RemoteHost "saturn","jupiter"
+
+.EXAMPLE
 	./deploy.ps1 -SkipBuild -RemoteHost "saturn"
 
 .EXAMPLE
@@ -58,7 +61,7 @@
 param(
 	[string]$Version,
 	[switch]$Dev,
-	[string]$RemoteHost = "",
+	[string[]]$RemoteHost = @(),
 	[string]$User = "root",
 	[string]$RemoteDir = "/tmp",
 	[string]$PackagePath,
@@ -75,7 +78,7 @@ $scriptDir = $PSScriptRoot
 $archiveDir = Join-Path $scriptDir "archive"
 
 if ($Quick) {
-	if ([string]::IsNullOrWhiteSpace($RemoteHost)) {
+	if (-not $RemoteHost -or $RemoteHost.Count -eq 0) {
 		throw "RemoteHost is required when using -Quick"
 	}
 
@@ -83,21 +86,14 @@ if ($Quick) {
 		Write-Host "Quick mode ignores -Version, -Dev, -PackagePath, and -SkipBuild." -ForegroundColor DarkYellow
 	}
 
-	$remoteTarget = "$User@$RemoteHost"
-	$quickPrefix = "source/compose.manager/"
-	$quickRemoteRoot = "/usr/local/emhttp/plugins/compose.manager"
-
 	$repoRoot = (& git -C $scriptDir rev-parse --show-toplevel 2>$null)
 	if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
 		throw "Unable to resolve git repository root from $scriptDir"
 	}
 	$repoRoot = $repoRoot.Trim()
 
-	Write-Host "Quick deploy mode (tracked staged+unstaged files):" -ForegroundColor Green
-	Write-Host "  Repo root     : $repoRoot" -ForegroundColor Gray
-	Write-Host "  Source scope  : source/compose.manager" -ForegroundColor Gray
-	Write-Host "  Remote root   : $quickRemoteRoot" -ForegroundColor Gray
-	Write-Host "  Remote target : $remoteTarget" -ForegroundColor Gray
+	$quickPrefix = "source/compose.manager/"
+	$quickRemoteRoot = "/usr/local/emhttp/plugins/compose.manager"
 
 	$statUnstaged = (& git -C $repoRoot diff --stat -- source/compose.manager)
 	$statStaged = (& git -C $repoRoot diff --cached --stat -- source/compose.manager)
@@ -120,7 +116,7 @@ if ($Quick) {
 	if (-not $changedFiles -or $changedFiles.Count -eq 0) {
 		Write-Host "No tracked staged/unstaged file changes found under source/compose.manager." -ForegroundColor Yellow
 		return @{
-			Host = $RemoteHost
+			Hosts = $RemoteHost
 			User = $User
 			Quick = $true
 			FileCount = 0
@@ -132,56 +128,64 @@ if ($Quick) {
 	Write-Host "Files queued for quick sync ($($changedFiles.Count)):" -ForegroundColor Green
 	$changedFiles | ForEach-Object { Write-Host "  $_" -ForegroundColor Gray }
 
-	$syncedFiles = @()
-	foreach ($relativePath in $changedFiles) {
-		if (-not $relativePath.StartsWith($quickPrefix, [System.StringComparison]::Ordinal)) {
-			continue
-		}
+	$allResults = @()
+	foreach ($host_ in $RemoteHost) {
+		$remoteTarget = "$User@$host_"
+		Write-Host "`nQuick deploy to $remoteTarget :" -ForegroundColor Green
 
-		$subPath = $relativePath.Substring($quickPrefix.Length)
-		if ([string]::IsNullOrWhiteSpace($subPath)) {
-			continue
-		}
-
-		$localPath = Join-Path $repoRoot ($relativePath -replace '/', [IO.Path]::DirectorySeparatorChar)
-		if (-not (Test-Path -Path $localPath -PathType Leaf)) {
-			Write-Host "Skipping missing local file: $relativePath" -ForegroundColor DarkYellow
-			continue
-		}
-
-		$remoteFile = "$quickRemoteRoot/$subPath"
-		$remoteParent = ($remoteFile -replace '/[^/]+$','')
-
-		$syncAction = "Upload changed file via SCP"
-		if ($PSCmdlet.ShouldProcess("$remoteTarget`:$remoteFile", $syncAction)) {
-			ssh -- "$remoteTarget" "mkdir -p '$remoteParent'"
-			if ($LASTEXITCODE -ne 0) {
-				throw "Failed to create remote directory $remoteParent (exit code $LASTEXITCODE)"
+		$syncedFiles = @()
+		foreach ($relativePath in $changedFiles) {
+			if (-not $relativePath.StartsWith($quickPrefix, [System.StringComparison]::Ordinal)) {
+				continue
 			}
 
-			scp -- "$localPath" "$remoteTarget`:$remoteFile"
-			if ($LASTEXITCODE -ne 0) {
-				throw "Failed to upload $relativePath to $remoteFile (exit code $LASTEXITCODE)"
+			$subPath = $relativePath.Substring($quickPrefix.Length)
+			if ([string]::IsNullOrWhiteSpace($subPath)) {
+				continue
 			}
+
+			$localPath = Join-Path $repoRoot ($relativePath -replace '/', [IO.Path]::DirectorySeparatorChar)
+			if (-not (Test-Path -Path $localPath -PathType Leaf)) {
+				Write-Host "Skipping missing local file: $relativePath" -ForegroundColor DarkYellow
+				continue
+			}
+
+			$remoteFile = "$quickRemoteRoot/$subPath"
+			$remoteParent = ($remoteFile -replace '/[^/]+$','')
+
+			$syncAction = "Upload changed file via SCP"
+			if ($PSCmdlet.ShouldProcess("$remoteTarget`:$remoteFile", $syncAction)) {
+				ssh -- "$remoteTarget" "mkdir -p '$remoteParent'"
+				if ($LASTEXITCODE -ne 0) {
+					throw "Failed to create remote directory $remoteParent on $host_ (exit code $LASTEXITCODE)"
+				}
+
+				scp -- "$localPath" "$remoteTarget`:$remoteFile"
+				if ($LASTEXITCODE -ne 0) {
+					throw "Failed to upload $relativePath to $remoteFile on $host_ (exit code $LASTEXITCODE)"
+				}
+			}
+
+			$syncedFiles += $relativePath
 		}
 
-		$syncedFiles += $relativePath
+		$allResults += @{
+			Host = $host_
+			User = $User
+			Quick = $true
+			FileCount = $syncedFiles.Count
+			Files = $syncedFiles
+			WhatIf = [bool]$WhatIfPreference
+		}
 	}
 
 	if ($WhatIfPreference) {
 		Write-Host "WhatIf simulation complete (quick mode)." -ForegroundColor Green
 	} else {
-		Write-Host "Quick deployment complete." -ForegroundColor Green
+		Write-Host "`nQuick deployment complete to $($RemoteHost.Count) host(s)." -ForegroundColor Green
 	}
 
-	return @{
-		Host = $RemoteHost
-		User = $User
-		Quick = $true
-		FileCount = $syncedFiles.Count
-		Files = $syncedFiles
-		WhatIf = [bool]$WhatIfPreference
-	}
+	return $allResults
 }
 
 # Generate dev version with timestamp if -Dev flag is used
@@ -255,7 +259,16 @@ if (-not $PackagePath) {
 }
 
 $packageName = Split-Path -Leaf $PackagePath
-$remotePackage = "$RemoteDir/$packageName"
+
+if (-not $RemoteHost -or $RemoteHost.Count -eq 0) {
+	Write-Host "No RemoteHost specified — build only, skipping deploy." -ForegroundColor Yellow
+	return @{
+		Hosts = @()
+		User = $User
+		PackagePath = $PackagePath
+		WhatIf = [bool]$WhatIfPreference
+	}
+}
 
 # Prefer plugin manifest generated by build.ps1 for this exact package; fallback to repository source .plg
 if ($buildInfo -and $buildInfo.PluginPath -and (Test-Path -Path $buildInfo.PluginPath -PathType Leaf)) {
@@ -267,50 +280,56 @@ if (-not (Test-Path -Path $pluginPath -PathType Leaf)) {
 	throw "Plugin file not found: $pluginPath"
 }
 $pluginName = Split-Path -Leaf $pluginPath
-$remotePlugin = "$RemoteDir/$pluginName"
 $installScriptLocal = Join-Path $scriptDir "install.sh"
 if (-not (Test-Path -Path $installScriptLocal -PathType Leaf)) {
 	throw "Install script not found: $installScriptLocal"
 }
-$remoteInstallScript = "$RemoteDir/install.sh"
-$remoteTarget = "$User@$RemoteHost"
 
-Write-Host "Deploying package, plugin manifest, and install.sh:" -ForegroundColor Green
-Write-Host "  Local package : $PackagePath" -ForegroundColor Gray
-Write-Host "  Local .plg    : $pluginPath" -ForegroundColor Gray
-Write-Host "  Local install : $installScriptLocal" -ForegroundColor Gray
-Write-Host "  Remote target : ${remoteTarget}:$RemoteDir" -ForegroundColor Gray
+$allResults = @()
+foreach ($host_ in $RemoteHost) {
+	$remoteTarget = "$User@$host_"
+	$remotePackage = "$RemoteDir/$packageName"
+	$remotePlugin = "$RemoteDir/$pluginName"
+	$remoteInstallScript = "$RemoteDir/install.sh"
 
-$uploadAction = "Upload package + .plg + install.sh via SCP"
-if ($PSCmdlet.ShouldProcess("${remoteTarget}:$RemoteDir/", $uploadAction)) {
-	Write-Host "Uploading package, .plg and install.sh via SCP..." -ForegroundColor Yellow
-	scp -- "$PackagePath" "$remoteTarget`:$RemoteDir/"
-	scp -- "$pluginPath" "$remoteTarget`:$RemoteDir/"
-	scp -- "$installScriptLocal" "$remoteTarget`:$remoteInstallScript"
-	if ($LASTEXITCODE -ne 0) {
-		throw "SCP upload failed with exit code $LASTEXITCODE"
+	Write-Host "`nDeploying to $remoteTarget :" -ForegroundColor Green
+	Write-Host "  Local package : $PackagePath" -ForegroundColor Gray
+	Write-Host "  Local .plg    : $pluginPath" -ForegroundColor Gray
+	Write-Host "  Local install : $installScriptLocal" -ForegroundColor Gray
+	Write-Host "  Remote target : ${remoteTarget}:$RemoteDir" -ForegroundColor Gray
+
+	$uploadAction = "Upload package + .plg + install.sh via SCP"
+	if ($PSCmdlet.ShouldProcess("${remoteTarget}:$RemoteDir/", $uploadAction)) {
+		Write-Host "Uploading package, .plg and install.sh via SCP..." -ForegroundColor Yellow
+		scp -- "$PackagePath" "$remoteTarget`:$RemoteDir/"
+		scp -- "$pluginPath" "$remoteTarget`:$RemoteDir/"
+		scp -- "$installScriptLocal" "$remoteTarget`:$remoteInstallScript"
+		if ($LASTEXITCODE -ne 0) {
+			throw "SCP upload to $host_ failed with exit code $LASTEXITCODE"
+		}
+	}
+
+	$installAction = "Execute remote install script"
+	if ($PSCmdlet.ShouldProcess($remoteTarget, $installAction)) {
+		Write-Host "Executing remote install script..." -ForegroundColor Yellow
+		ssh -- "$remoteTarget" "bash '$remoteInstallScript' '$remotePackage' '$remotePlugin' && rm -f '$remoteInstallScript'"
+		if ($LASTEXITCODE -ne 0) {
+			throw "Remote install script on $host_ failed with exit code $LASTEXITCODE"
+		}
+	}
+
+	$allResults += @{
+		Host = $host_
+		User = $User
+		PackagePath = $PackagePath
+		RemotePackage = $remotePackage
+		WhatIf = [bool]$WhatIfPreference
 	}
 }
-
-$installAction = "Execute remote install script"
-if ($PSCmdlet.ShouldProcess($remoteTarget, $installAction)) {
-	Write-Host "Executing remote install script..." -ForegroundColor Yellow
-	ssh -- "$remoteTarget" "bash '$remoteInstallScript' '$remotePackage' '$remotePlugin' && rm -f '$remoteInstallScript'"
-	if ($LASTEXITCODE -ne 0) {
-		throw "Remote install script failed with exit code $LASTEXITCODE"
-	}
-}
-
 
 if ($WhatIfPreference) {
 	Write-Host "WhatIf simulation complete." -ForegroundColor Green
 } else {
-	Write-Host "Deployment complete." -ForegroundColor Green
+	Write-Host "`nDeployment complete to $($RemoteHost.Count) host(s)." -ForegroundColor Green
 }
-return @{
-	Host = $RemoteHost
-	User = $User
-	PackagePath = $PackagePath
-	RemotePackage = $remotePackage
-	WhatIf = [bool]$WhatIfPreference
-}
+return $allResults

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -14,7 +14,7 @@
 	Generate a development build with timestamp: YYYY.MM.DD.HHmm
 
 .PARAMETER RemoteHost
-	Remote hostname(s) or IP(s). Accepts a single value or a comma-separated list.
+	Remote hostname(s) or IP(s). Accepts a single value or multiple values using PowerShell array syntax (e.g. "saturn","jupiter").
 
 .PARAMETER User
 	SSH username.

--- a/source/compose.manager/Compose.page
+++ b/source/compose.manager/Compose.page
@@ -3,7 +3,7 @@ Type="xmenu"
 Title="Docker Compose"
 Tag="fa-cubes"
 Code="f1b3"
-Nchan="docker_load"
+Nchan="../../dynamix.docker.manager/nchan/docker_load"
 Cond="$var['fsState'] == 'Started' && exec('/etc/rc.d/rc.docker status | grep -v \"not\"') && exec(\"grep '^SHOW_COMPOSE_IN_HEADER_MENU=' /boot/config/plugins/compose.manager/compose.manager.cfg 2>/dev/null | grep 'true'\")"
 ---
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.switchbutton.css')?>">

--- a/source/compose.manager/Compose.page
+++ b/source/compose.manager/Compose.page
@@ -3,7 +3,8 @@ Type="xmenu"
 Title="Docker Compose"
 Tag="fa-cubes"
 Code="f1b3"
-Cond="$var['fsState'] == 'Started' && exec('/etc/rc.d/rc.docker status | grep -v "not"') && exec(\"grep '^SHOW_COMPOSE_IN_HEADER_MENU=' /boot/config/plugins/compose.manager/compose.manager.cfg 2>/dev/null | grep 'true'\")"
+Nchan="docker_load"
+Cond="$var['fsState'] == 'Started' && exec('/etc/rc.d/rc.docker status | grep -v \"not\"') && exec(\"grep '^SHOW_COMPOSE_IN_HEADER_MENU=' /boot/config/plugins/compose.manager/compose.manager.cfg 2>/dev/null | grep 'true'\")"
 ---
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.switchbutton.css')?>">
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.filetree.css')?>">

--- a/source/compose.manager/compose.manager.dashboard.page
+++ b/source/compose.manager/compose.manager.dashboard.page
@@ -696,6 +696,26 @@ $script .= <<<'EOT'
         );
     });
 
+    // Right-click anywhere on a dashboard stack row opens the stack context menu
+    $(document).on('contextmenu', '.compose-dash-stack', function(e) {
+        var $icon = $(this).find('.compose-dash-icon').first();
+        if ($icon.length) {
+            e.preventDefault();
+            e.stopPropagation();
+            $icon.trigger($.Event('click', { pageX: e.pageX, pageY: e.pageY }));
+        }
+    });
+
+    // Right-click anywhere on a dashboard container row opens the container context menu
+    $(document).on('contextmenu', '.compose-dash-container', function(e) {
+        var $icon = $(this).find('.compose-dash-ct-icon').first();
+        if ($icon.length) {
+            e.preventDefault();
+            e.stopPropagation();
+            $icon.trigger($.Event('click', { pageX: e.pageX, pageY: e.pageY }));
+        }
+    });
+
     // Check if any stacks are visible (for "no stacks" message)
     function noStacks() {
         if ($('#compose_dash_content .compose-dash-stack:visible').length === 0 && $('#compose_dash_content .compose-dash-stack').length > 0) {

--- a/source/compose.manager/compose.manager.page
+++ b/source/compose.manager/compose.manager.page
@@ -2,7 +2,7 @@ Author="dcflachs"
 Title="Compose"
 Type="php"
 Menu="Docker:2"
-Nchan="docker_load"
+Nchan="../../dynamix.docker.manager/nchan/docker_load"
 Cond="$var['fsState'] == 'Started' && exec('/etc/rc.d/rc.docker status | grep -v \"not\"') && (!file_exists('/boot/config/plugins/compose.manager/compose.manager.cfg') ? true : exec(\"grep '^SHOW_COMPOSE_IN_HEADER_MENU=' /boot/config/plugins/compose.manager/compose.manager.cfg 2>/dev/null | grep -v 'true'\"))"
 ---
 <?php

--- a/source/compose.manager/compose.manager.page
+++ b/source/compose.manager/compose.manager.page
@@ -2,6 +2,7 @@ Author="dcflachs"
 Title="Compose"
 Type="php"
 Menu="Docker:2"
+Nchan="docker_load"
 Cond="$var['fsState'] == 'Started' && exec('/etc/rc.d/rc.docker status | grep -v \"not\"') && (!file_exists('/boot/config/plugins/compose.manager/compose.manager.cfg') ? true : exec(\"grep '^SHOW_COMPOSE_IN_HEADER_MENU=' /boot/config/plugins/compose.manager/compose.manager.cfg 2>/dev/null | grep -v 'true'\"))"
 ---
 <?php

--- a/source/compose.manager/php/compose_list.php
+++ b/source/compose.manager/php/compose_list.php
@@ -57,11 +57,16 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
 
     // Collect container names for the hide-from-docker feature (data attribute)
     $containerNamesList = [];
+    // Collect short container IDs for CPU/MEM load mapping (docker stats uses 12-char short IDs)
+    $containerIdsList = [];
     foreach ($projectContainers as $ct) {
         $n = $ct['Names'] ?? '';
         if ($n) $containerNamesList[] = $n;
+        $ctId = $ct['ID'] ?? '';
+        if ($ctId) $containerIdsList[] = substr($ctId, 0, 12);
     }
     $containerNamesAttr = htmlspecialchars(json_encode($containerNamesList), ENT_QUOTES, 'UTF-8');
+    $containerIdsAttr = htmlspecialchars(implode(',', $containerIdsList), ENT_QUOTES, 'UTF-8');
 
     // Determine states
     $isrunning = $runningCount > 0;
@@ -186,7 +191,7 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
     $hasBuild = $stackInfo->hasBuildConfig() ? '1' : '0';
 
     // Main row - Docker tab structure with expand arrow on left
-    $o .= "<tr class='compose-sortable' id='stack-row-$id' data-project='$projectHtml' data-projectname='$projectNameHtml' data-path='$pathHtml' data-isup='$isup' data-profiles='$profilesJson' data-webui='$webuiUrlHtml' data-containers='$containerNamesAttr' data-hasbuild='$hasBuild' data-invalid-indirect='" . ($hasInvalidIndirect ? '1' : '0') . "' data-invalid-indirect-path='$invalidIndirectPathHtml'>";
+    $o .= "<tr class='compose-sortable' id='stack-row-$id' data-project='$projectHtml' data-projectname='$projectNameHtml' data-path='$pathHtml' data-isup='$isup' data-profiles='$profilesJson' data-webui='$webuiUrlHtml' data-containers='$containerNamesAttr' data-ctids='$containerIdsAttr' data-hasbuild='$hasBuild' data-invalid-indirect='" . ($hasInvalidIndirect ? '1' : '0') . "' data-invalid-indirect-path='$invalidIndirectPathHtml'>";
 
 // Arrow column
     $o .= "<td class='col-arrow'>";
@@ -235,6 +240,13 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
     $uptimeClass = $isrunning ? 'green-text' : 'grey-text';
     $o .= "<td class='col-uptime'><span class='$uptimeClass'>$uptimeDisplay</span></td>";
 
+    // CPU & Memory column (advanced only) — populated in real-time via dockerload WebSocket
+    $o .= "<td class='cm-advanced col-load compose-load-cell'>";
+    $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
+    $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
+    $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0b</span>";
+    $o .= "</td>";
+
     // Description column (advanced only)
     $o .= "<td class='cm-advanced col-description' style='overflow-wrap:break-word;word-wrap:break-word;'>";
     if ($hasInvalidIndirect) {
@@ -254,7 +266,7 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
 
     // Expandable details row
     $o .= "<tr class='stack-details-row' id='details-row-$id' style='display:none;'>";
-    $o .= "<td colspan='9' class='stack-details-cell' style='padding:0 0 0 60px;background:var(--dynamix-tablesorter-tbody-row-bg-color);'>";
+    $o .= "<td colspan='10' class='stack-details-cell' style='padding:0 0 0 60px;background:var(--dynamix-tablesorter-tbody-row-bg-color);'>";
     $o .= "<div class='stack-details-container' id='details-container-$id' style='padding:8px 16px;'>";
     $o .= "<i class='fa fa-spinner fa-spin compose-spinner'></i> Loading containers...";
     $o .= "</div>";
@@ -264,7 +276,7 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
 
 // If no stacks found, show a message
 if ($stackCount === 0) {
-    $o = "<tr><td colspan='9' style='text-align:center;padding:20px;color:var(--alt-text-color);'>No Docker Compose stacks found. Click 'Add New Stack' to create one.</td></tr>";
+    $o = "<tr><td colspan='10' style='text-align:center;padding:20px;color:var(--alt-text-color);'>No Docker Compose stacks found. Click 'Add New Stack' to create one.</td></tr>";
 }
 
 // Output the HTML

--- a/source/compose.manager/php/compose_list.php
+++ b/source/compose.manager/php/compose_list.php
@@ -243,12 +243,12 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
     // CPU & Memory column (advanced only) — populated in real-time via dockerload WebSocket
     $o .= "<td class='cm-advanced col-load compose-load-cell'>";
     if ($isrunning) {
-        $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
+        $o .= "<span class='compose-stack-cpu-$id compose-load-cpu'>0%</span>";
         $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
-        $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B / 0B</span>";
+        $o .= "<span class='compose-stack-mem-$id compose-text-muted compose-load-mem'>0B / 0B</span>";
     } else {
-        $o .= "<span class='compose-stack-cpu-$id compose-text-muted'>-</span>";
-        $o .= "<span class='compose-stack-mem-$id' style='display:none'></span>";
+        $o .= "<span class='compose-stack-cpu-$id compose-text-muted compose-load-cpu'>-</span>";
+        $o .= "<span class='compose-stack-mem-$id compose-load-mem' style='display:none'></span>";
     }
     $o .= "</td>";
 

--- a/source/compose.manager/php/compose_list.php
+++ b/source/compose.manager/php/compose_list.php
@@ -244,7 +244,7 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
     $o .= "<td class='cm-advanced col-load compose-load-cell'>";
     $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
     $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
-    $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0b</span>";
+    $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B</span>";
     $o .= "</td>";
 
     // Description column (advanced only)

--- a/source/compose.manager/php/compose_list.php
+++ b/source/compose.manager/php/compose_list.php
@@ -242,9 +242,14 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
 
     // CPU & Memory column (advanced only) — populated in real-time via dockerload WebSocket
     $o .= "<td class='cm-advanced col-load compose-load-cell'>";
-    $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
-    $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
-    $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B</span>";
+    if ($isrunning) {
+        $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
+        $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
+        $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B</span>";
+    } else {
+        $o .= "<span class='compose-stack-cpu-$id compose-text-muted'>-</span>";
+        $o .= "<span class='compose-stack-mem-$id' style='display:none'></span>";
+    }
     $o .= "</td>";
 
     // Description column (advanced only)

--- a/source/compose.manager/php/compose_list.php
+++ b/source/compose.manager/php/compose_list.php
@@ -245,7 +245,7 @@ foreach (StackInfo::allFromRoot($compose_root) as $stackInfo) {
     if ($isrunning) {
         $o .= "<span class='compose-stack-cpu-$id'>0%</span>";
         $o .= "<div class='usage-disk mm'><span id='compose-stack-cpu-$id' style='width:0'></span><span></span></div>";
-        $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B</span>";
+        $o .= "<br><span class='compose-stack-mem-$id compose-text-muted'>0B / 0B</span>";
     } else {
         $o .= "<span class='compose-stack-cpu-$id compose-text-muted'>-</span>";
         $o .= "<span class='compose-stack-mem-$id' style='display:none'></span>";

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -47,9 +47,16 @@ function compose_manager_cpu_spec_count($cpuSpec)
     return $count;
 }
 $cpus = function_exists('cpu_list') ? cpu_list() : [];
-$cpuCount = (!empty($cpus) && isset($cpus[0]))
-    ? count($cpus) * compose_manager_cpu_spec_count($cpus[0])
-    : (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
+$cpuCount = 0;
+foreach ($cpus as $cpuSpec) {
+    $cpuCount += compose_manager_cpu_spec_count($cpuSpec);
+}
+if ($cpuCount <= 0) {
+    $cpuCount = (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
+}
+if ($cpuCount <= 0) {
+    $cpuCount = 1;
+}
 
 // Note: Stack list is now loaded asynchronously via compose_list.php
 // This improves page load time by deferring expensive docker commands
@@ -1831,18 +1838,22 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
                     var totalCpu = 0;
                     var totalMemUsedBytes = 0;
+                    var totalMemLimitBytes = 0;
                     var matched = 0;
                     idList.forEach(function(ctId) {
                         if (ctId && composeLoadById[ctId]) {
                             totalCpu += composeLoadById[ctId].cpu;
                             totalMemUsedBytes += composeLoadById[ctId].memUsedBytes || 0;
+                            totalMemLimitBytes += composeLoadById[ctId].memLimitBytes || 0;
                             matched++;
                         }
                     });
 
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
-                        var stackMemTotal = composeSystemMemBytes > 0 ? formatBytes(composeSystemMemBytes) : '0B';
+                        var stackMemTotal = totalMemLimitBytes > 0
+                            ? formatBytes(totalMemLimitBytes)
+                            : (composeSystemMemBytes > 0 ? formatBytes(composeSystemMemBytes) : '0B');
                         var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + stackMemTotal;
                         $('.compose-stack-cpu-' + entry.stackId).removeClass('compose-text-muted').text(aggCpu);
                         $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
@@ -1870,14 +1881,12 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                         var cpuRaw = parseFloat(parts[1]) || 0;
                         var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
                         var memPair = parseMemUsagePair(parts[2]);
-                        var memParts = String(parts[2] || '').split('/');
-                        var memAvailText = (memParts[1] || '').trim();
                         composeLoadById[parts[0]] = {
                             cpu: cpuNorm,
                             cpuText: cpuNorm + '%',
                             mem: parts[2],
                             memUsedBytes: memPair.used,
-                            memAvailText: memAvailText,
+                            memLimitBytes: memPair.limit,
                             ts: now
                         };
                     }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -20,7 +20,9 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
 
 // CPU count for load normalization (matches Docker manager's cpu_list approach)
 $cpus = function_exists('cpu_list') ? cpu_list() : [];
-$cpuCount = count($cpus) > 0 ? count($cpus) * count(preg_split('/[,-]/', $cpus[0])) : (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
+$cpuCount = (!empty($cpus) && isset($cpus[0]))
+    ? count($cpus) * count(preg_split('/[,-]/', $cpus[0]))
+    : (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
 
 // Note: Stack list is now loaded asynchronously via compose_list.php
 // This improves page load time by deferring expensive docker commands

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -18,6 +18,10 @@ $hideComposeFromDocker = ($cfg['HIDE_COMPOSE_FROM_DOCKER'] ?? 'false') === 'true
 // Get Docker Compose CLI version
 $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') ?? '');
 
+// CPU count for load normalization (matches Docker manager's cpu_list approach)
+$cpus = function_exists('cpu_list') ? cpu_list() : [];
+$cpuCount = count($cpus) > 0 ? count($cpus) * count(preg_split('/[,-]/', $cpus[0])) : (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
+
 // Note: Stack list is now loaded asynchronously via compose_list.php
 // This improves page load time by deferring expensive docker commands
 ?>
@@ -85,7 +89,7 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
         width: 15%;
     }
 
-    /* Advanced-view column widths (9 visible columns)
+    /* Advanced-view column widths (10 visible columns)
    Arrow + Icon stay fixed px; Description + Path get the most %. */
     #compose_stacks.cm-advanced-view thead th.col-arrow {
         width: 1%;
@@ -111,12 +115,16 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
         width: 6%
     }
 
+    #compose_stacks.cm-advanced-view thead th.col-load {
+        width: 12%
+    }
+
     #compose_stacks.cm-advanced-view thead th.col-description {
-        width: 28%
+        width: 22%
     }
 
     #compose_stacks.cm-advanced-view thead th.col-path {
-        width: 28%
+        width: 22%
     }
 
     #compose_stacks.cm-advanced-view thead th.col-autostart {
@@ -176,6 +184,28 @@ $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') 
         z-index: 100 !important; 
     }
 
+    /* CPU & Memory load display (matches Docker manager usage-disk style) */
+    .compose-load-cell {
+        white-space: nowrap;
+        font-size: 0.9em;
+    }
+    .compose-load-cell .usage-disk.mm {
+        height: 3px;
+        margin: 3px 20px 0 0;
+        position: relative;
+        background-color: var(--usage-disk-background-color, #e0e0e0);
+    }
+    .compose-load-cell .usage-disk.mm > span:first-child {
+        position: absolute;
+        left: 0;
+        height: 3px;
+        background-color: var(--gray-400, #888);
+    }
+    .compose-load-cell .usage-disk.mm > span:last-child {
+        position: relative;
+        z-index: 1;
+    }
+
 </style>
 
 <?php
@@ -210,6 +240,33 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     var showComposeOnTop = <?php echo json_encode($showComposeOnTop); ?>;
     var hideComposeFromDocker = <?php echo json_encode($hideComposeFromDocker); ?>;
     var composeCliVersion = <?php echo json_encode($composeVersion); ?>;
+    var composeCpuCount = <?php echo json_encode($cpuCount); ?>;
+
+    // Parse docker stats memory string "123.4MiB / 2GiB" to bytes (first value only)
+    function parseMemToBytes(memStr) {
+        if (!memStr) return 0;
+        var parts = memStr.split('/');
+        var val = (parts[0] || '').trim();
+        var match = val.match(/([\d.]+)\s*(KiB|MiB|GiB|TiB|B)/i);
+        if (!match) return 0;
+        var num = parseFloat(match[1]);
+        switch (match[2].toLowerCase()) {
+            case 'tib': return num * 1099511627776;
+            case 'gib': return num * 1073741824;
+            case 'mib': return num * 1048576;
+            case 'kib': return num * 1024;
+            default: return num;
+        }
+    }
+
+    // Format bytes to human-readable string
+    function formatBytes(bytes) {
+        if (bytes <= 0) return '0B';
+        if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + 'GiB';
+        if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + 'MiB';
+        if (bytes >= 1024) return (bytes / 1024).toFixed(1) + 'KiB';
+        return bytes + 'B';
+    }
 
     // ═══════════════════════════════════════════════════════════════════
     // Standard factory functions for container and stack identity objects
@@ -457,7 +514,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 }, 'daemon', 'error');
                 clearTimeout(composeTimers.load);
                 hideComposeSpinner();
-                $('#compose_list').html('<tr><td colspan="9" class="compose-status-danger" style="text-align:center;padding:20px;">Failed to load stack list. Please refresh the page.</td></tr>');
+                $('#compose_list').html('<tr><td colspan="10" class="compose-status-danger" style="text-align:center;padding:20px;">Failed to load stack list. Please refresh the page.</td></tr>');
 
                 // Reject the promise so callers can handle the error
                 try { reject({xhr: xhr, status: status, error: error}); } catch (e) { reject(error); }
@@ -1596,6 +1653,79 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 });
             }
         })();
+
+        // ── CPU & Memory load via dockerload Nchan channel ─────────────
+        // Subscribe to the same dockerload WebSocket that the Docker tab uses.
+        // Data format per line: "shortID;CPU%;MemUsage"
+        if (typeof NchanSubscriber === 'function') {
+            var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
+            composeDockerLoad.on('message', function(msg) {
+                var data = msg.split('\n');
+                // Build a map of shortID -> {cpu, mem} for quick lookup
+                var loadMap = {};
+                for (var i = 0, row; row = data[i]; i++) {
+                    var parts = row.split(';');
+                    if (parts.length >= 3) {
+                        var cpuRaw = parseFloat(parts[1]) || 0;
+                        var cpuNorm = Math.round(Math.min(cpuRaw / composeCpuCount, 100) * 100) / 100;
+                        loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
+                    }
+                }
+
+                // Update per-container CPU & MEM elements in expanded detail tables
+                for (var shortId in loadMap) {
+                    var info = loadMap[shortId];
+                    $('.compose-cpu-' + shortId).text(info.cpuText);
+                    $('.compose-mem-' + shortId).text(info.mem);
+                    $('#compose-cpu-' + shortId).css('width', info.cpuText);
+                }
+
+                // Aggregate per-stack totals and update stack-level cells.
+                // Use data-ctids embedded at render time so aggregation works
+                // even before the stack details have been expanded.
+                $('#compose_stacks tr.compose-sortable').each(function() {
+                    var stackId = ($(this).attr('id') || '').replace('stack-row-', '');
+                    if (!stackId) return;
+
+                    // Primary: short IDs baked into the row by compose_list.php
+                    var ctidsAttr = $(this).attr('data-ctids') || '';
+                    var idList = ctidsAttr ? ctidsAttr.split(',') : [];
+
+                    // Fallback: if detail panel was expanded, stackContainersCache
+                    // may have more/different IDs (e.g. after a compose up added a service)
+                    if (idList.length === 0) {
+                        var containers = stackContainersCache[stackId];
+                        if (containers && containers.length > 0) {
+                            containers.forEach(function(ct) {
+                                var ctId = String(ct.id || '').substring(0, 12);
+                                if (ctId) idList.push(ctId);
+                            });
+                        }
+                    }
+                    if (idList.length === 0) return;
+
+                    var totalCpu = 0;
+                    var totalMemBytes = 0;
+                    var matched = 0;
+                    idList.forEach(function(ctId) {
+                        if (ctId && loadMap[ctId]) {
+                            totalCpu += loadMap[ctId].cpu;
+                            totalMemBytes += parseMemToBytes(loadMap[ctId].mem);
+                            matched++;
+                        }
+                    });
+
+                    if (matched > 0) {
+                        var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
+                        var aggMem = formatBytes(totalMemBytes);
+                        $('.compose-stack-cpu-' + stackId).text(aggCpu);
+                        $('#compose-stack-cpu-' + stackId).css('width', aggCpu);
+                        $('.compose-stack-mem-' + stackId).text(aggMem);
+                    }
+                });
+            });
+            composeDockerLoad.start();
+        }
     });
 
     function addStack() {
@@ -4353,6 +4483,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         html += '<th class="cm-advanced ct-col-tag">Tag</th>';
         html += '<th class="cm-advanced ct-col-net">Network</th>';
         html += '<th class="cm-advanced ct-col-ip">Container IP</th>';
+        html += '<th class="cm-advanced ct-col-load">CPU &amp; Memory</th>';
         html += '<th class="ct-col-cport">Container Port</th>';
         html += '<th class="ct-col-lport">LAN IP:Port</th>';
         html += '</tr></thead>';
@@ -4502,6 +4633,13 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
             // Container IP
             html += '<td class="cm-advanced" style="white-space:nowrap;"><span class="docker_readmore">' + ipAddresses.map(composeEscapeHtml).join('<br>') + '</span></td>';
+
+            // CPU & Memory load (advanced only) — populated by dockerload WebSocket
+            html += '<td class="cm-advanced compose-load-cell">';
+            html += '<span class="compose-cpu-' + containerId + '">0%</span>';
+            html += '<div class="usage-disk mm"><span id="compose-cpu-' + containerId + '" style="width:0"></span><span></span></div>';
+            html += '<br><span class="compose-mem-' + containerId + ' compose-text-muted">0 / 0</span>';
+            html += '</td>';
 
             // Container Port
             html += '<td style="white-space:nowrap;"><span class="docker_readmore">' + containerPorts.map(composeEscapeHtml).join('<br>') + '</span></td>';
@@ -5380,6 +5518,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     <th class="col-update">Update</th>
                     <th class="col-containers">Containers</th>
                     <th class="col-uptime">Uptime</th>
+                    <th class="cm-advanced col-load">CPU &amp; Memory</th>
                     <th class="cm-advanced col-description">Description</th>
                     <th class="cm-advanced col-path">Path</th>
                     <th class="nine col-autostart">Autostart</th>
@@ -5387,7 +5526,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             </thead>
             <tbody id="compose_list">
                 <tr>
-                    <td colspan='9'></td>
+                    <td colspan='10'></td>
                 </tr>
             </tbody>
         </table>

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -5311,6 +5311,24 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         }
     });
 
+    // Right-click anywhere on a stack row opens the stack context menu
+    $(document).on('contextmenu', 'tr.compose-sortable[id^="stack-row-"]', function(e) {
+        var $icon = $(this).find('[data-stackid]').first();
+        if ($icon.length) {
+            e.preventDefault();
+            $icon.trigger($.Event('click', { pageX: e.pageX, pageY: e.pageY }));
+        }
+    });
+
+    // Right-click anywhere on a container detail row opens the container context menu
+    $(document).on('contextmenu', '#compose_stacks tr[data-container][data-stackid]', function(e) {
+        var $icon = $(this).find('.hand[id^="ct-"]').first();
+        if ($icon.length) {
+            e.preventDefault();
+            $icon.trigger($.Event('click', { pageX: e.pageX, pageY: e.pageY }));
+        }
+    });
+
     // Close actions menu when clicking outside
     $(document).on('click', function(e) {
         if (!$(e.target).closest('#stack-actions-modal, .stack-kebab-btn').length) {

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1663,13 +1663,17 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
             composeDockerLoad.on('message', function(msg) {
                 var data = msg.split('\n');
-                // Build a map of shortID -> {cpu, mem} for quick lookup
-                var loadMap = {};
-                for (var i = 0, row; row = data[i]; i++) {
+                var i = 0;
+                var row = data[i];
+                while (row) {
                     var parts = row.split(';');
                     if (parts.length >= 3) {
                         var cpuRaw = parseFloat(parts[1]) || 0;
                         var cpuNorm = Math.round(Math.min(cpuRaw / composeCpuCount, 100) * 100) / 100;
+                        loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
+                    }
+                    i++;
+                    row = data[i];
                         loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
                     }
                 }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -4684,7 +4684,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         html += '<th class="cm-advanced ct-col-tag">Tag</th>';
         html += '<th class="cm-advanced ct-col-net">Network</th>';
         html += '<th class="cm-advanced ct-col-ip">Container IP</th>';
-        html += '<th class="cm-advanced ct-col-load">CPU &amp; Memory</th>';
+        html += '<th class="cm-advanced ct-col-load">CPU &amp; Memory load</th>';
         html += '<th class="ct-col-cport">Container Port</th>';
         html += '<th class="ct-col-lport">LAN IP:Port</th>';
         html += '</tr></thead>';
@@ -5724,7 +5724,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     <th class="col-update">Update</th>
                     <th class="col-containers">Containers</th>
                     <th class="col-uptime">Uptime</th>
-                    <th class="cm-advanced col-load">CPU &amp; Memory</th>
+                    <th class="cm-advanced col-load">CPU &amp; Memory load</th>
                     <th class="cm-advanced col-description">Description</th>
                     <th class="cm-advanced col-path">Path</th>
                     <th class="nine col-autostart">Autostart</th>

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1667,7 +1667,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 var row = data[i];
                 while (row) {
                     var parts = row.split(';');
-                    if (parts.length >= 3) {
+                        var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
                         var cpuRaw = parseFloat(parts[1]) || 0;
                         var cpuNorm = Math.round(Math.min(cpuRaw / composeCpuCount, 100) * 100) / 100;
                         loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1444,6 +1444,10 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     // When animate=true (user clicked toggle), run a simple symmetric transition.
     // When false (page load), instant class toggle.
     function applyListView(animate) {
+        // Sync the dockerload WebSocket with the view mode.
+        if (typeof window.composeDockerLoadToggle === 'function') {
+            window.composeDockerLoadToggle(isComposeAdvancedMode());
+        }
         var advanced = isComposeAdvancedMode();
         var $table = $('#compose_stacks');
         var $advanced = $table.find('.cm-advanced');
@@ -1677,10 +1681,23 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         })();
 
         // ── CPU & Memory load via dockerload Nchan channel ─────────────
-        // Subscribe to the same dockerload WebSocket that the Docker tab uses.
-        // Data format per line: "shortID;CPU%;MemUsage"
+        // Only runs in advanced view (load column is hidden in basic view).
+        // composeDockerLoadToggle(true/false) is called from applyListView()
+        // so the socket starts/stops whenever the user switches view modes.
         if (typeof NchanSubscriber === 'function') {
             var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
+            var composeDockerLoadRunning = false;
+
+            window.composeDockerLoadToggle = function(enable) {
+                if (enable && !composeDockerLoadRunning) {
+                    composeDockerLoad.start();
+                    composeDockerLoadRunning = true;
+                } else if (!enable && composeDockerLoadRunning) {
+                    composeDockerLoad.stop();
+                    composeDockerLoadRunning = false;
+                }
+            };
+
             composeDockerLoad.on('message', function(msg) {
                 var data = msg.split('\n');
                 var loadMap = {};
@@ -1749,7 +1766,11 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     }
                 });
             });
-            composeDockerLoad.start();
+            // Start immediately if already in advanced view
+            if (isComposeAdvancedMode()) {
+                composeDockerLoad.start();
+                composeDockerLoadRunning = true;
+            }
         }
     });
 

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -18,6 +18,13 @@ $hideComposeFromDocker = ($cfg['HIDE_COMPOSE_FROM_DOCKER'] ?? 'false') === 'true
 // Get Docker Compose CLI version
 $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') ?? '');
 
+// Host total memory in bytes for stack-level memory denominator.
+$composeSystemMemBytes = 0;
+$memKbRaw = trim(shell_exec("awk '/^MemTotal:/ {print \$2}' /proc/meminfo 2>/dev/null") ?? '');
+if (is_numeric($memKbRaw)) {
+    $composeSystemMemBytes = (int)$memKbRaw * 1024;
+}
+
 // CPU count for load normalization (matches Docker manager's cpu_list approach).
 // cpu_list() returns thread_siblings_list entries (e.g. "0-3,8-11").
 // We expand each range segment so "0-3" counts as 4, not 2 endpoints.
@@ -262,6 +269,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     var showComposeOnTop = <?php echo json_encode($showComposeOnTop); ?>;
     var hideComposeFromDocker = <?php echo json_encode($hideComposeFromDocker); ?>;
     var composeCliVersion = <?php echo json_encode($composeVersion); ?>;
+    var composeSystemMemBytes = <?php echo json_encode($composeSystemMemBytes); ?>;
     var composeCpuCount = <?php echo json_encode($cpuCount); ?>;
 
     // Parse a single memory value (for example "123.4MiB" or "512MB") to bytes.
@@ -1816,22 +1824,19 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
                     var totalCpu = 0;
                     var totalMemUsedBytes = 0;
-                    var aggregateMemAvailText = '';
                     var matched = 0;
                     idList.forEach(function(ctId) {
                         if (ctId && composeLoadById[ctId]) {
                             totalCpu += composeLoadById[ctId].cpu;
                             totalMemUsedBytes += composeLoadById[ctId].memUsedBytes || 0;
-                            if (!aggregateMemAvailText && composeLoadById[ctId].memAvailText) {
-                                aggregateMemAvailText = composeLoadById[ctId].memAvailText;
-                            }
                             matched++;
                         }
                     });
 
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
-                        var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + (aggregateMemAvailText || '0B');
+                        var stackMemTotal = composeSystemMemBytes > 0 ? formatBytes(composeSystemMemBytes) : '0B';
+                        var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + stackMemTotal;
                         $('.compose-stack-cpu-' + entry.stackId).removeClass('compose-text-muted').text(aggCpu);
                         $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
                         $('.compose-stack-mem-' + entry.stackId).show().text(aggMem);

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -18,10 +18,30 @@ $hideComposeFromDocker = ($cfg['HIDE_COMPOSE_FROM_DOCKER'] ?? 'false') === 'true
 // Get Docker Compose CLI version
 $composeVersion = trim(shell_exec('docker compose version --short 2>/dev/null') ?? '');
 
-// CPU count for load normalization (matches Docker manager's cpu_list approach)
+// CPU count for load normalization (matches Docker manager's cpu_list approach).
+// cpu_list() returns thread_siblings_list entries (e.g. "0-3,8-11").
+// We expand each range segment so "0-3" counts as 4, not 2 endpoints.
+function compose_manager_cpu_spec_count($cpuSpec)
+{
+    $count = 0;
+    foreach (explode(',', trim((string)$cpuSpec)) as $segment) {
+        $segment = trim($segment);
+        if ($segment === '') continue;
+        if (strpos($segment, '-') !== false) {
+            [$start, $end] = explode('-', $segment, 2);
+            $start = (int)$start;
+            $end   = (int)$end;
+            if ($end < $start) [$start, $end] = [$end, $start];
+            $count += max(0, $end - $start + 1);
+        } else {
+            $count += 1;
+        }
+    }
+    return $count;
+}
 $cpus = function_exists('cpu_list') ? cpu_list() : [];
 $cpuCount = (!empty($cpus) && isset($cpus[0]))
-    ? count($cpus) * count(preg_split('/[,-]/', $cpus[0]))
+    ? count($cpus) * compose_manager_cpu_spec_count($cpus[0])
     : (int)trim(shell_exec('nproc 2>/dev/null') ?: '1');
 
 // Note: Stack list is now loaded asynchronously via compose_list.php

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -432,6 +432,9 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 // Insert the loaded content
                 $('#compose_list').html(data);
 
+                // Signal load subscribers (e.g. dockerload cache) that the list changed
+                $(document).trigger('composeListRefreshed');
+
                 // Initialize UI components for the newly loaded content
                 initStackListUI();
 
@@ -1688,6 +1691,30 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
             var composeDockerLoadRunning = false;
 
+            // Cache of { stackId, containerIds[] } built from the DOM once after
+            // composeLoadlist() and reused until the row count changes.
+            // Avoids O(stacks) DOM traversal + string splits on every stats tick.
+            var composeStackIndex = null;
+
+            function buildComposeStackIndex() {
+                composeStackIndex = [];
+                $('#compose_stacks tr.compose-sortable').each(function() {
+                    var stackId = ($(this).attr('id') || '').replace('stack-row-', '');
+                    if (!stackId) return;
+                    var ctidsAttr = $(this).attr('data-ctids') || '';
+                    composeStackIndex.push({
+                        stackId: stackId,
+                        containerIds: ctidsAttr ? ctidsAttr.split(',') : []
+                    });
+                });
+            }
+
+            // Invalidate the cache when the list refreshes so that added/removed
+            // stacks are picked up on the next stats tick.
+            $(document).on('composeListRefreshed', function() {
+                composeStackIndex = null;
+            });
+
             window.composeDockerLoadToggle = function(enable) {
                 if (enable && !composeDockerLoadRunning) {
                     composeDockerLoad.start();
@@ -1723,20 +1750,20 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 }
 
                 // Aggregate per-stack totals and update stack-level cells.
-                // Use data-ctids embedded at render time so aggregation works
-                // even before the stack details have been expanded.
-                $('#compose_stacks tr.compose-sortable').each(function() {
-                    var stackId = ($(this).attr('id') || '').replace('stack-row-', '');
-                    if (!stackId) return;
+                // Build (or reuse) the stack→container index.
+                var currentRowCount = $('#compose_stacks tr.compose-sortable').length;
+                if (!composeStackIndex || composeStackIndex.length !== currentRowCount) {
+                    buildComposeStackIndex();
+                }
 
+                composeStackIndex.forEach(function(entry) {
                     // Primary: short IDs baked into the row by compose_list.php
-                    var ctidsAttr = $(this).attr('data-ctids') || '';
-                    var idList = ctidsAttr ? ctidsAttr.split(',') : [];
+                    var idList = entry.containerIds.slice();
 
-                    // Fallback: if detail panel was expanded, stackContainersCache
-                    // may have more/different IDs (e.g. after a compose up added a service)
+                    // Fallback: if the detail panel was expanded, stackContainersCache
+                    // may have fresher IDs (e.g. after a compose up added a service)
                     if (idList.length === 0) {
-                        var containers = stackContainersCache[stackId];
+                        var containers = stackContainersCache[entry.stackId];
                         if (containers && containers.length > 0) {
                             containers.forEach(function(ct) {
                                 var ctId = String(ct.id || '').substring(0, 12);
@@ -1760,9 +1787,9 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
                         var aggMem = formatBytes(totalMemBytes);
-                        $('.compose-stack-cpu-' + stackId).text(aggCpu);
-                        $('#compose-stack-cpu-' + stackId).css('width', aggCpu);
-                        $('.compose-stack-mem-' + stackId).text(aggMem);
+                        $('.compose-stack-cpu-' + entry.stackId).text(aggCpu);
+                        $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
+                        $('.compose-stack-mem-' + entry.stackId).text(aggMem);
                     }
                 });
             });

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1816,20 +1816,22 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
                     var totalCpu = 0;
                     var totalMemUsedBytes = 0;
-                    var totalMemLimitBytes = 0;
+                    var aggregateMemAvailText = '';
                     var matched = 0;
                     idList.forEach(function(ctId) {
                         if (ctId && composeLoadById[ctId]) {
                             totalCpu += composeLoadById[ctId].cpu;
                             totalMemUsedBytes += composeLoadById[ctId].memUsedBytes || 0;
-                            totalMemLimitBytes += composeLoadById[ctId].memLimitBytes || 0;
+                            if (!aggregateMemAvailText && composeLoadById[ctId].memAvailText) {
+                                aggregateMemAvailText = composeLoadById[ctId].memAvailText;
+                            }
                             matched++;
                         }
                     });
 
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
-                        var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + formatBytes(totalMemLimitBytes);
+                        var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + (aggregateMemAvailText || '0B');
                         $('.compose-stack-cpu-' + entry.stackId).removeClass('compose-text-muted').text(aggCpu);
                         $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
                         $('.compose-stack-mem-' + entry.stackId).show().text(aggMem);
@@ -1856,12 +1858,14 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                         var cpuRaw = parseFloat(parts[1]) || 0;
                         var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
                         var memPair = parseMemUsagePair(parts[2]);
+                        var memParts = String(parts[2] || '').split('/');
+                        var memAvailText = (memParts[1] || '').trim();
                         composeLoadById[parts[0]] = {
                             cpu: cpuNorm,
                             cpuText: cpuNorm + '%',
                             mem: parts[2],
                             memUsedBytes: memPair.used,
-                            memLimitBytes: memPair.limit,
+                            memAvailText: memAvailText,
                             ts: now
                         };
                     }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -4641,9 +4641,14 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
             // CPU & Memory load (advanced only) — populated by dockerload WebSocket
             html += '<td class="cm-advanced compose-load-cell">';
-            html += '<span class="compose-cpu-' + containerId + '">0%</span>';
-            html += '<div class="usage-disk mm"><span id="compose-cpu-' + containerId + '" style="width:0"></span><span></span></div>';
-            html += '<br><span class="compose-mem-' + containerId + ' compose-text-muted">0 / 0</span>';
+            if (state === 'running') {
+                html += '<span class="compose-cpu-' + containerId + '">0%</span>';
+                html += '<div class="usage-disk mm"><span id="compose-cpu-' + containerId + '" style="width:0"></span><span></span></div>';
+                html += '<br><span class="compose-mem-' + containerId + ' compose-text-muted">0 / 0</span>';
+            } else {
+                html += '<span class="compose-cpu-' + containerId + ' compose-text-muted">-</span>';
+                html += '<span class="compose-mem-' + containerId + '" style="display:none"></span>';
+            }
             html += '</td>';
 
             // Container Port

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1663,19 +1663,18 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
             composeDockerLoad.on('message', function(msg) {
                 var data = msg.split('\n');
+                var loadMap = {};
                 var i = 0;
                 var row = data[i];
                 while (row) {
                     var parts = row.split(';');
-                        var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
+                    if (parts.length >= 3) {
                         var cpuRaw = parseFloat(parts[1]) || 0;
-                        var cpuNorm = Math.round(Math.min(cpuRaw / composeCpuCount, 100) * 100) / 100;
+                        var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
                         loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
                     }
                     i++;
                     row = data[i];
-                        loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
-                    }
                 }
 
                 // Update per-container CPU & MEM elements in expanded detail tables

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -218,6 +218,13 @@ $cpuCount = (!empty($cpus) && isset($cpus[0]))
         white-space: nowrap;
         font-size: 0.9em;
     }
+    .compose-load-cell .compose-load-cpu,
+    .compose-load-cell .compose-load-mem {
+        display: block;
+    }
+    .compose-load-cell .compose-load-mem {
+        margin-top: 2px;
+    }
     .compose-load-cell .usage-disk.mm {
         height: 3px;
         margin: 3px 20px 0 0;

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1710,7 +1710,15 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         // Only runs in advanced view (load column is hidden in basic view).
         // composeDockerLoadToggle(true/false) is called from applyListView()
         // so the socket starts/stops whenever the user switches view modes.
-        if (typeof NchanSubscriber === 'function') {
+        function initComposeDockerLoadSubscriber() {
+            if (typeof NchanSubscriber !== 'function') {
+                return false;
+            }
+            if (window.composeDockerLoadInitialized) {
+                return true;
+            }
+            window.composeDockerLoadInitialized = true;
+
             var composeDockerLoad = new NchanSubscriber('/sub/dockerload', {subscriber: 'websocket'});
             var composeDockerLoadRunning = false;
 
@@ -1830,6 +1838,19 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 composeDockerLoad.start();
                 composeDockerLoadRunning = true;
             }
+            return true;
+        }
+
+        // Standalone compose mode can race script load order; retry briefly
+        // so delayed NchanSubscriber availability still initializes dockerload.
+        if (!initComposeDockerLoadSubscriber()) {
+            var composeDockerLoadInitAttempts = 0;
+            var composeDockerLoadInitTimer = setInterval(function() {
+                composeDockerLoadInitAttempts++;
+                if (initComposeDockerLoadSubscriber() || composeDockerLoadInitAttempts >= 40) {
+                    clearInterval(composeDockerLoadInitTimer);
+                }
+            }, 250);
         }
     });
 

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -1726,6 +1726,24 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             // composeLoadlist() and reused until the row count changes.
             // Avoids O(stacks) DOM traversal + string splits on every stats tick.
             var composeStackIndex = null;
+            var composeLoadById = {};
+            var composeLoadStaleMs = 15000;
+
+            function isComposeLoadVisible() {
+                if (!isComposeAdvancedMode()) return false;
+                if (document.visibilityState === 'hidden') return false;
+                var $table = $('#compose_stacks');
+                if (!$table.length) return false;
+                var $tabPanel = $table.closest('[role="tabpanel"]');
+                if ($tabPanel.length && $tabPanel[0].style.display === 'none') return false;
+                return true;
+            }
+
+            function clearContainerLoad(shortId) {
+                $('.compose-cpu-' + shortId).addClass('compose-text-muted').text('-');
+                $('#compose-cpu-' + shortId).css('width', '0');
+                $('.compose-mem-' + shortId).hide();
+            }
 
             function buildComposeStackIndex() {
                 composeStackIndex = [];
@@ -1744,6 +1762,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             // stacks are picked up on the next stats tick.
             $(document).on('composeListRefreshed', function() {
                 composeStackIndex = null;
+                composeLoadById = {};
             });
 
             window.composeDockerLoadToggle = function(enable) {
@@ -1756,37 +1775,21 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 }
             };
 
-            composeDockerLoad.on('message', function(msg) {
-                var data = msg.split('\n');
-                var loadMap = {};
-                var i = 0;
-                var row = data[i];
-                while (row) {
-                    var parts = row.split(';');
-                    if (parts.length >= 3) {
-                        var cpuRaw = parseFloat(parts[1]) || 0;
-                        var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
-                        var memPair = parseMemUsagePair(parts[2]);
-                        loadMap[parts[0]] = {
-                            cpu: cpuNorm,
-                            cpuText: cpuNorm + '%',
-                            mem: parts[2],
-                            memUsedBytes: memPair.used,
-                            memLimitBytes: memPair.limit
-                        };
+            function pruneStaleLoadEntries(now) {
+                var staleIds = [];
+                for (var knownId in composeLoadById) {
+                    if ((now - composeLoadById[knownId].ts) > composeLoadStaleMs) {
+                        staleIds.push(knownId);
                     }
-                    i++;
-                    row = data[i];
                 }
+                staleIds.forEach(function(staleId) {
+                    delete composeLoadById[staleId];
+                    clearContainerLoad(staleId);
+                });
+                return staleIds.length > 0;
+            }
 
-                // Update per-container CPU & MEM elements in expanded detail tables
-                for (var shortId in loadMap) {
-                    var info = loadMap[shortId];
-                    $('.compose-cpu-' + shortId).text(info.cpuText);
-                    $('.compose-mem-' + shortId).text(info.mem);
-                    $('#compose-cpu-' + shortId).css('width', info.cpuText);
-                }
-
+            function renderStackAggregates() {
                 // Aggregate per-stack totals and update stack-level cells.
                 // Build (or reuse) the stack→container index.
                 var currentRowCount = $('#compose_stacks tr.compose-sortable').length;
@@ -1816,10 +1819,10 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     var totalMemLimitBytes = 0;
                     var matched = 0;
                     idList.forEach(function(ctId) {
-                        if (ctId && loadMap[ctId]) {
-                            totalCpu += loadMap[ctId].cpu;
-                            totalMemUsedBytes += loadMap[ctId].memUsedBytes || 0;
-                            totalMemLimitBytes += loadMap[ctId].memLimitBytes || 0;
+                        if (ctId && composeLoadById[ctId]) {
+                            totalCpu += composeLoadById[ctId].cpu;
+                            totalMemUsedBytes += composeLoadById[ctId].memUsedBytes || 0;
+                            totalMemLimitBytes += composeLoadById[ctId].memLimitBytes || 0;
                             matched++;
                         }
                     });
@@ -1827,12 +1830,68 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
                         var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + formatBytes(totalMemLimitBytes);
-                        $('.compose-stack-cpu-' + entry.stackId).text(aggCpu);
+                        $('.compose-stack-cpu-' + entry.stackId).removeClass('compose-text-muted').text(aggCpu);
                         $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
-                        $('.compose-stack-mem-' + entry.stackId).text(aggMem);
+                        $('.compose-stack-mem-' + entry.stackId).show().text(aggMem);
+                    } else {
+                        $('.compose-stack-cpu-' + entry.stackId).addClass('compose-text-muted').text('-');
+                        $('#compose-stack-cpu-' + entry.stackId).css('width', '0');
+                        $('.compose-stack-mem-' + entry.stackId).hide();
                     }
                 });
+            }
+
+            composeDockerLoad.on('message', function(msg) {
+                if (!isComposeLoadVisible()) {
+                    return;
+                }
+
+                var now = Date.now();
+                var data = msg.split('\n');
+                var i = 0;
+                var row = data[i];
+                while (row) {
+                    var parts = row.split(';');
+                    if (parts.length >= 3) {
+                        var cpuRaw = parseFloat(parts[1]) || 0;
+                        var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
+                        var memPair = parseMemUsagePair(parts[2]);
+                        composeLoadById[parts[0]] = {
+                            cpu: cpuNorm,
+                            cpuText: cpuNorm + '%',
+                            mem: parts[2],
+                            memUsedBytes: memPair.used,
+                            memLimitBytes: memPair.limit,
+                            ts: now
+                        };
+                    }
+                    i++;
+                    row = data[i];
+                }
+
+                pruneStaleLoadEntries(now);
+
+                // Update per-container CPU & MEM elements in expanded detail tables
+                for (var shortId in composeLoadById) {
+                    var info = composeLoadById[shortId];
+                    $('.compose-cpu-' + shortId).removeClass('compose-text-muted').text(info.cpuText);
+                    $('.compose-mem-' + shortId).show().text(info.mem);
+                    $('#compose-cpu-' + shortId).css('width', info.cpuText);
+                }
+
+                renderStackAggregates();
             });
+
+            // If dockerload pauses/stalls, drop stale values on a timer so the UI
+            // falls back to placeholders instead of showing frozen metrics forever.
+            setInterval(function() {
+                if (!isComposeLoadVisible()) {
+                    return;
+                }
+                if (pruneStaleLoadEntries(Date.now())) {
+                    renderStackAggregates();
+                }
+            }, 3000);
             // Start immediately if already in advanced view
             if (isComposeAdvancedMode()) {
                 composeDockerLoad.start();

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -264,21 +264,44 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     var composeCliVersion = <?php echo json_encode($composeVersion); ?>;
     var composeCpuCount = <?php echo json_encode($cpuCount); ?>;
 
-    // Parse docker stats memory string "123.4MiB / 2GiB" to bytes (first value only)
-    function parseMemToBytes(memStr) {
-        if (!memStr) return 0;
-        var parts = memStr.split('/');
-        var val = (parts[0] || '').trim();
-        var match = val.match(/([\d.]+)\s*(KiB|MiB|GiB|TiB|B)/i);
+    // Parse a single memory value (for example "123.4MiB" or "512MB") to bytes.
+    // Supports both IEC (KiB, MiB, GiB, TiB) and SI (kB, MB, GB, TB) suffixes.
+    function parseMemValueToBytes(memVal) {
+        if (!memVal) return 0;
+        var cleaned = String(memVal).trim();
+        if (!cleaned) return 0;
+        var match = cleaned.match(/([\d.]+)\s*([kmgt]?i?b)?/i);
         if (!match) return 0;
+
         var num = parseFloat(match[1]);
-        switch (match[2].toLowerCase()) {
+        if (!isFinite(num)) return 0;
+        var unit = (match[2] || 'b').toLowerCase();
+
+        switch (unit) {
+            case 'tb':  return num * 1000000000000;
             case 'tib': return num * 1099511627776;
+            case 'gb':  return num * 1000000000;
             case 'gib': return num * 1073741824;
+            case 'mb':  return num * 1000000;
             case 'mib': return num * 1048576;
+            case 'kb':  return num * 1000;
             case 'kib': return num * 1024;
-            default: return num;
+            default:    return num;
         }
+    }
+
+    // Parse docker stats memory string "used / limit" into bytes.
+    function parseMemUsagePair(memStr) {
+        if (!memStr) return {used: 0, limit: 0};
+        var parts = String(memStr).split('/');
+        var used = parseMemValueToBytes(parts[0] || '');
+        var limit = parseMemValueToBytes(parts[1] || '');
+        return {used: used, limit: limit};
+    }
+
+    // Backward-compatible helper used by existing code paths.
+    function parseMemToBytes(memStr) {
+        return parseMemUsagePair(memStr).used;
     }
 
     // Format bytes to human-readable string
@@ -1735,7 +1758,14 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     if (parts.length >= 3) {
                         var cpuRaw = parseFloat(parts[1]) || 0;
                         var cpuNorm = Math.round(Math.min(cpuRaw / Math.max(composeCpuCount, 1), 100) * 100) / 100;
-                        loadMap[parts[0]] = {cpu: cpuNorm, cpuText: cpuNorm + '%', mem: parts[2]};
+                        var memPair = parseMemUsagePair(parts[2]);
+                        loadMap[parts[0]] = {
+                            cpu: cpuNorm,
+                            cpuText: cpuNorm + '%',
+                            mem: parts[2],
+                            memUsedBytes: memPair.used,
+                            memLimitBytes: memPair.limit
+                        };
                     }
                     i++;
                     row = data[i];
@@ -1774,19 +1804,21 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     if (idList.length === 0) return;
 
                     var totalCpu = 0;
-                    var totalMemBytes = 0;
+                    var totalMemUsedBytes = 0;
+                    var totalMemLimitBytes = 0;
                     var matched = 0;
                     idList.forEach(function(ctId) {
                         if (ctId && loadMap[ctId]) {
                             totalCpu += loadMap[ctId].cpu;
-                            totalMemBytes += parseMemToBytes(loadMap[ctId].mem);
+                            totalMemUsedBytes += loadMap[ctId].memUsedBytes || 0;
+                            totalMemLimitBytes += loadMap[ctId].memLimitBytes || 0;
                             matched++;
                         }
                     });
 
                     if (matched > 0) {
                         var aggCpu = Math.round(totalCpu * 100) / 100 + '%';
-                        var aggMem = formatBytes(totalMemBytes);
+                        var aggMem = formatBytes(totalMemUsedBytes) + ' / ' + formatBytes(totalMemLimitBytes);
                         $('.compose-stack-cpu-' + entry.stackId).text(aggCpu);
                         $('#compose-stack-cpu-' + entry.stackId).css('width', aggCpu);
                         $('.compose-stack-mem-' + entry.stackId).text(aggMem);
@@ -4712,7 +4744,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             if (state === 'running') {
                 html += '<span class="compose-cpu-' + containerId + '">0%</span>';
                 html += '<div class="usage-disk mm"><span id="compose-cpu-' + containerId + '" style="width:0"></span><span></span></div>';
-                html += '<br><span class="compose-mem-' + containerId + ' compose-text-muted">0 / 0</span>';
+                html += '<br><span class="compose-mem-' + containerId + ' compose-text-muted">0B / 0B</span>';
             } else {
                 html += '<span class="compose-cpu-' + containerId + ' compose-text-muted">-</span>';
                 html += '<span class="compose-mem-' + containerId + '" style="display:none"></span>';

--- a/source/compose.manager/php/util.php
+++ b/source/compose.manager/php/util.php
@@ -1747,9 +1747,12 @@ class StackInfo
      * silently skipping folders with no compose file or invalid structure.
      *
      * @param string $composeRoot Compose projects root directory
+     * @param bool   $skipDocker  If true, skip the batch docker ps preload
+     *                            (returns stacks with empty container lists
+     *                            for fast skeleton rendering).
      * @return self[]
      */
-    public static function allFromRoot(string $composeRoot): array
+    public static function allFromRoot(string $composeRoot, bool $skipDocker = false): array
     {
         $stacks = [];
         foreach (self::listProjectFolders($composeRoot) as $project) {
@@ -1759,6 +1762,15 @@ class StackInfo
                 // skip non-stack directories (no compose file, invalid structure, etc.)
                 clientDebug("[allFromRoot] Skipped project '$project': " . $e->getMessage(), null, 'daemon', 'debug');
             }
+        }
+
+        if ($skipDocker) {
+            // Set empty container lists so getContainerList() won't trigger
+            // per-stack docker calls.
+            foreach ($stacks as $stack) {
+                $stack->setContainerList([]);
+            }
+            return $stacks;
         }
 
         // Batch-preload container data with a single docker ps call to avoid

--- a/source/compose.manager/styles/comboButton.css
+++ b/source/compose.manager/styles/comboButton.css
@@ -279,10 +279,6 @@
   }
 
   /* Column width distribution (totals ~100%) */
-  .compose-ct-table .ct-col-icon {
-    width: 3%;
-  }
-
   .compose-ct-table .ct-col-name {
     width: 13%;
   }

--- a/source/compose.manager/styles/comboButton.css
+++ b/source/compose.manager/styles/comboButton.css
@@ -279,28 +279,36 @@
   }
 
   /* Column width distribution (totals ~100%) */
-  .compose-ct-table .ct-col-name {
-    width: 18%;
+  .compose-ct-table .ct-col-icon {
+    width: 3%;
   }
 
-  .compose-ct-table .ct-col-update {
+  .compose-ct-table .ct-col-name {
     width: 13%;
   }
 
-  .compose-ct-table .ct-col-source {
-    width: 17%;
-  }
-
-  .compose-ct-table .ct-col-tag {
+  .compose-ct-table .ct-col-update {
     width: 12%;
   }
 
-  .compose-ct-table .ct-col-net {
+  .compose-ct-table .ct-col-source {
+    width: 14%;
+  }
+
+  .compose-ct-table .ct-col-tag {
     width: 10%;
   }
 
+  .compose-ct-table .ct-col-net {
+    width: 8%;
+  }
+
   .compose-ct-table .ct-col-ip {
-    width: 10%;
+    width: 8%;
+  }
+
+  .compose-ct-table .ct-col-load {
+    width: 12%;
   }
 
   .compose-ct-table .ct-col-cport {

--- a/tests/unit/ComposeListHtmlTest.php
+++ b/tests/unit/ComposeListHtmlTest.php
@@ -95,6 +95,7 @@ class ComposeListHtmlTest extends TestCase
         $this->assertStringContainsString("data-project=", $source);
         $this->assertStringContainsString("data-projectname=", $source);
         $this->assertStringContainsString("data-isup=", $source);
+        $this->assertStringContainsString("data-ctids=", $source);
     }
 
     // ===========================================
@@ -106,6 +107,14 @@ class ComposeListHtmlTest extends TestCase
         $source = $this->getPageSource();
         // Advanced-only columns should include 'cm-advanced' (not bare 'advanced')
         $this->assertMatchesRegularExpression("/class='[^']*\\bcm-advanced\\b[^']*'/", $source);
+    }
+
+    public function testAdvancedLoadColumnMarkupExists(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString("col-load compose-load-cell", $source);
+        $this->assertStringContainsString("compose-stack-cpu-", $source);
+        $this->assertStringContainsString("compose-stack-mem-", $source);
     }
 
     // ===========================================
@@ -129,6 +138,7 @@ class ComposeListHtmlTest extends TestCase
         $source = $this->getPageSource();
         $this->assertStringContainsString('No Docker Compose stacks found', $source);
         $this->assertStringContainsString('Add New Stack', $source);
+        $this->assertStringContainsString("colspan='10'", $source);
     }
 
     // ===========================================

--- a/tests/unit/ComposeManagerMainSourceTest.php
+++ b/tests/unit/ComposeManagerMainSourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposeManager\Tests;
+
+use PluginTests\TestCase;
+
+/**
+ * Source-level tests for compose_manager_main.php.
+ *
+ * These verify key CPU/memory load logic markers in the page source so
+ * regressions are caught even when the page cannot be executed in unit tests.
+ */
+class ComposeManagerMainSourceTest extends TestCase
+{
+    private string $mainPagePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mainPagePath = __DIR__ . '/../../source/compose.manager/php/compose_manager_main.php';
+        $this->assertFileExists($this->mainPagePath, 'compose_manager_main.php must exist');
+    }
+
+    private function getPageSource(): string
+    {
+        return file_get_contents($this->mainPagePath);
+    }
+
+    public function testCpuSpecCountHelperExists(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('function compose_manager_cpu_spec_count($cpuSpec)', $source);
+        $this->assertStringContainsString('explode(\',\', trim((string)$cpuSpec))', $source);
+    }
+
+    public function testCpuCountSumsAllCpuSpecs(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('$cpuCount = 0;', $source);
+        $this->assertStringContainsString('foreach ($cpus as $cpuSpec)', $source);
+        $this->assertStringContainsString('$cpuCount += compose_manager_cpu_spec_count($cpuSpec);', $source);
+    }
+
+    public function testCpuCountHasFallbackGuards(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString("trim(shell_exec('nproc 2>/dev/null') ?: '1')", $source);
+        $this->assertStringContainsString('if ($cpuCount <= 0) {', $source);
+        $this->assertStringContainsString('$cpuCount = 1;', $source);
+    }
+
+    public function testStackAggregationTracksMemoryLimits(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('var totalMemLimitBytes = 0;', $source);
+        $this->assertStringContainsString('totalMemLimitBytes += composeLoadById[ctId].memLimitBytes || 0;', $source);
+        $this->assertStringContainsString('var stackMemTotal = totalMemLimitBytes > 0', $source);
+    }
+
+    public function testDockerLoadMapStoresParsedLimitBytes(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('var memPair = parseMemUsagePair(parts[2]);', $source);
+        $this->assertStringContainsString('memLimitBytes: memPair.limit,', $source);
+    }
+}


### PR DESCRIPTION
**What changed**

Added real-time CPU and memory usage display to the advanced view mode for both individual containers and aggregate stack totals — matching the existing Docker manager tab's load display.

**Implementation:**
- Subscribe to the existing `dockerload` Nchan WebSocket channel (`/sub/dockerload`) which streams `docker stats` data as `shortID;CPU%;MemUsage` per line
- CPU values are normalized by total thread count (using `cpu_list()` from Helpers.php, with `nproc` fallback) to show per-system percentages consistent with the Docker tab
- Stack-level aggregates are computed by summing CPU/memory across all member containers, using `data-ctids` baked into each stack row at render time so aggregation works immediately — no need to expand the stack first
- Stopped stacks and containers show a `-` placeholder instead of misleading `0%` / `0B` since they never receive stats data
- Added `Nchan="docker_load"` header to `Compose.page` so the docker_load daemon starts when using the standalone Tasks menu entry (Docker tab already provides it when embedded)

**Files changed:**
- `compose_manager_main.php` — PHP `$cpuCount` calculation, CSS for usage bars, `parseMemToBytes()`/`formatBytes()` JS helpers, NchanSubscriber message handler with per-container updates and per-stack aggregation, CPU/MEM column in container detail tables
- `compose_list.php` — Collects container short IDs into `data-ctids` attribute on stack rows, adds CPU/MEM column cell to stack table, updates colspans 9→10
- `comboButton.css` — Column width adjustments for container detail table to fit the new CPU & Memory column
- `Compose.page` — Added `Nchan="docker_load"` header
- `util.php` — Added `$skipDocker` parameter to `allFromRoot()` for skeleton rendering without docker ps calls

**Related issues**
Closes #72

**Checklist**
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation (docs/, README, or plugin docs)
- [ ] Linted/formatted the code
- [x] Verified on Unraid or CI

**Testing notes**
1. Open the Docker → Compose tab in advanced view mode — each running stack should show aggregate CPU% and memory with a thin usage bar
2. Expand a stack — individual containers should show their own CPU% and memory (format: `used / limit` from docker stats)
3. Stopped stacks should display `-` in the load column, not `0%`
4. Open the standalone Compose page (Tasks → Docker Compose) — load data should still appear since `Nchan="docker_load"` is now set
5. Start/stop a stack — after the list reloads, `data-ctids` and display should update correctly

**Notes**
No migration steps or backward compatibility issues. The feature is purely additive and only visible in advanced view mode (`cm-advanced` CSS class). The Nchan subscription gracefully degrades — if `NchanSubscriber` is not available, the load column simply stays at its placeholder value.