### PR TITLE
Enhance YAML loading with custom tags support and error handling

### DIFF
--- a/source/compose.manager/include/ComposeManager.php
+++ b/source/compose.manager/include/ComposeManager.php
@@ -2312,18 +2312,6 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         return jsyaml.DEFAULT_SCHEMA.extend(types);
     }
 
-    function hasComposeCustomYamlTag(content) {
-        if (!content) return false;
-        return /!(?:override|reset|merge)\b/.test(content) || /!<(?:override|reset|merge)>/.test(content);
-    }
-
-    function stripComposeCustomYamlTags(content) {
-        if (!content) return content;
-        return content
-            .replace(/!<(?:override|reset|merge)>/g, '')
-            .replace(/!(?:override|reset|merge)\b/g, '');
-    }
-
     function loadComposeYaml(content) {
         var input = content || '';
 
@@ -2331,20 +2319,12 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             composeYamlSchemaCache = buildComposeYamlSchema();
         }
 
-        try {
-            if (composeYamlSchemaCache) {
-                return jsyaml.load(input, {
-                    schema: composeYamlSchemaCache
-                });
-            }
-            return jsyaml.load(input);
-        } catch (e) {
-            var message = String((e && e.message) || '');
-            if (/unknown tag/i.test(message) && hasComposeCustomYamlTag(input)) {
-                return jsyaml.load(stripComposeCustomYamlTags(input));
-            }
-            throw e;
+        if (composeYamlSchemaCache) {
+            return jsyaml.load(input, {
+                schema: composeYamlSchemaCache
+            });
         }
+        return jsyaml.load(input);
     }
     function applyDesc(myID) {
         var newDesc = $("#newDesc" + myID).val();

--- a/source/compose.manager/include/ComposeManager.php
+++ b/source/compose.manager/include/ComposeManager.php
@@ -2312,9 +2312,16 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         return jsyaml.DEFAULT_SCHEMA.extend(types);
     }
 
-    function stripUnsupportedYamlTags(content) {
+    function hasComposeCustomYamlTag(content) {
+        if (!content) return false;
+        return /!(?:override|reset|merge)\b/.test(content) || /!<(?:override|reset|merge)>/.test(content);
+    }
+
+    function stripComposeCustomYamlTags(content) {
         if (!content) return content;
-        return content.replace(/!<[^>\n]+>|![A-Za-z_][A-Za-z0-9_.-]*/g, '');
+        return content
+            .replace(/!<(?:override|reset|merge)>/g, '')
+            .replace(/!(?:override|reset|merge)\b/g, '');
     }
 
     function loadComposeYaml(content) {
@@ -2332,8 +2339,9 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             }
             return jsyaml.load(input);
         } catch (e) {
-            if (e && /unknown tag/i.test(String(e.message || ''))) {
-                return jsyaml.load(stripUnsupportedYamlTags(input));
+            var message = String((e && e.message) || '');
+            if (/unknown tag/i.test(message) && hasComposeCustomYamlTag(input)) {
+                return jsyaml.load(stripComposeCustomYamlTags(input));
             }
             throw e;
         }

--- a/source/compose.manager/include/ComposeManager.php
+++ b/source/compose.manager/include/ComposeManager.php
@@ -2280,9 +2280,27 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     }
 
     var composeYamlSchemaCache = null;
+    var composeYamlCustomTagPattern = /(^|[\s:[{,\-])!(override|reset|merge)\b/m;
+
+    function getComposeYamlLibrary() {
+        if (typeof jsyaml !== 'undefined') {
+            return jsyaml;
+        }
+
+        if (typeof window !== 'undefined' && window.jsyaml) {
+            return window.jsyaml;
+        }
+
+        return null;
+    }
+
+    function composeYamlContainsCustomTags(content) {
+        return composeYamlCustomTagPattern.test(content || '');
+    }
 
     function buildComposeYamlSchema() {
-        if (!jsyaml || typeof jsyaml.Type !== 'function' || !jsyaml.DEFAULT_SCHEMA || typeof jsyaml.DEFAULT_SCHEMA.extend !== 'function') {
+        var yamlLib = getComposeYamlLibrary();
+        if (!yamlLib || typeof yamlLib.Type !== 'function' || !yamlLib.DEFAULT_SCHEMA || typeof yamlLib.DEFAULT_SCHEMA.extend !== 'function') {
             return null;
         }
 
@@ -2292,7 +2310,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
         customTags.forEach(function(tag) {
             kinds.forEach(function(kind) {
-                types.push(new jsyaml.Type(tag, {
+                types.push(new yamlLib.Type(tag, {
                     kind: kind,
                     resolve: function() {
                         return true;
@@ -2309,22 +2327,27 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
             });
         });
 
-        return jsyaml.DEFAULT_SCHEMA.extend(types);
+        return yamlLib.DEFAULT_SCHEMA.extend(types);
     }
 
     function loadComposeYaml(content) {
         var input = content || '';
+        var yamlLib = getComposeYamlLibrary();
+
+        if (!yamlLib || typeof yamlLib.load !== 'function') {
+            throw new Error('YAML parser is unavailable. Please reload the page and try again.');
+        }
 
         if (!composeYamlSchemaCache) {
             composeYamlSchemaCache = buildComposeYamlSchema();
         }
 
         if (composeYamlSchemaCache) {
-            return jsyaml.load(input, {
+            return yamlLib.load(input, {
                 schema: composeYamlSchemaCache
             });
         }
-        return jsyaml.load(input);
+        return yamlLib.load(input);
     }
     function applyDesc(myID) {
         var newDesc = $("#newDesc" + myID).val();
@@ -4146,7 +4169,9 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
                 editorModal.labelsData = {
                     mainDoc: mainDoc,
-                    overrideDoc: overrideDoc
+                    overrideDoc: overrideDoc,
+                    overrideContent: overrideData.content || '',
+                    overrideHasCustomTags: composeYamlContainsCustomTags(overrideData.content || '')
                 };
 
                 renderLabelsUI(mainDoc, overrideDoc);
@@ -4469,7 +4494,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
         // Save labels if modified
         if (editorModal.modifiedLabels.size > 0) {
-            savePromises.push(saveLabels());
+            savePromises.push(saveLabels(saveErrors));
         }
 
         $.when.apply($, savePromises).then(function() {
@@ -4623,11 +4648,18 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
     }
 
     // Save labels to override file
-    function saveLabels() {
+    function saveLabels(saveErrors) {
         var project = editorModal.currentProject;
 
         if (!editorModal.labelsData) {
             return $.Deferred().reject().promise();
+        }
+
+        if (editorModal.labelsData.overrideHasCustomTags) {
+            if (saveErrors) {
+                saveErrors.push('WebUI labels cannot be saved because compose.override.yaml uses !override, !reset, or !merge tags. Edit the override file directly to preserve those tags.');
+            }
+            return $.Deferred().resolve(false).promise();
         }
 
         var mainDoc = editorModal.labelsData.mainDoc;
@@ -4681,6 +4713,8 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     editorModal.originalLabels[serviceKey + '_webui'] = $('#label-' + serviceKey + '-webui').val() || '';
                     editorModal.originalLabels[serviceKey + '_shell'] = $('#label-' + serviceKey + '-shell').val() || '';
                 }
+                editorModal.labelsData.overrideContent = rawOverride;
+                editorModal.labelsData.overrideHasCustomTags = false;
                 editorModal.modifiedLabels.clear();
                 updateTabModifiedState();
                 updateSaveButtonState();

--- a/source/compose.manager/include/ComposeManager.php
+++ b/source/compose.manager/include/ComposeManager.php
@@ -2279,6 +2279,65 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
         $("#" + myID).tooltipster("close");
     }
 
+    var composeYamlSchemaCache = null;
+
+    function buildComposeYamlSchema() {
+        if (!jsyaml || typeof jsyaml.Type !== 'function' || !jsyaml.DEFAULT_SCHEMA || typeof jsyaml.DEFAULT_SCHEMA.extend !== 'function') {
+            return null;
+        }
+
+        var customTags = ['!override', '!reset', '!merge'];
+        var kinds = ['scalar', 'sequence', 'mapping'];
+        var types = [];
+
+        customTags.forEach(function(tag) {
+            kinds.forEach(function(kind) {
+                types.push(new jsyaml.Type(tag, {
+                    kind: kind,
+                    resolve: function() {
+                        return true;
+                    },
+                    construct: function(data) {
+                        if (data === null || data === undefined) {
+                            if (kind === 'sequence') return [];
+                            if (kind === 'mapping') return {};
+                            return '';
+                        }
+                        return data;
+                    }
+                }));
+            });
+        });
+
+        return jsyaml.DEFAULT_SCHEMA.extend(types);
+    }
+
+    function stripUnsupportedYamlTags(content) {
+        if (!content) return content;
+        return content.replace(/!<[^>\n]+>|![A-Za-z_][A-Za-z0-9_.-]*/g, '');
+    }
+
+    function loadComposeYaml(content) {
+        var input = content || '';
+
+        if (!composeYamlSchemaCache) {
+            composeYamlSchemaCache = buildComposeYamlSchema();
+        }
+
+        try {
+            if (composeYamlSchemaCache) {
+                return jsyaml.load(input, {
+                    schema: composeYamlSchemaCache
+                });
+            }
+            return jsyaml.load(input);
+        } catch (e) {
+            if (e && /unknown tag/i.test(String(e.message || ''))) {
+                return jsyaml.load(stripUnsupportedYamlTags(input));
+            }
+            throw e;
+        }
+    }
     function applyDesc(myID) {
         var newDesc = $("#newDesc" + myID).val();
         var project = $("#" + myID).attr("data-scriptname");
@@ -2315,7 +2374,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                 var rawComposefile = JSON.parse(rawComposefile);
 
                 if ((rawComposefile.result == 'success')) {
-                    var main_doc = jsyaml.load(rawComposefile.content);
+                    var main_doc = loadComposeYaml(rawComposefile.content);
 
                     for (var service_key in main_doc.services) {
                         var service = main_doc.services[service_key];
@@ -4085,10 +4144,10 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
                     throw new Error('Failed to load compose file');
                 }
 
-                var mainDoc = jsyaml.load(composeData.content) || {
+                var mainDoc = loadComposeYaml(composeData.content) || {
                     services: {}
                 };
-                var overrideDoc = jsyaml.load(overrideData.content || '') || {
+                var overrideDoc = loadComposeYaml(overrideData.content || '') || {
                     services: {}
                 };
 
@@ -4279,7 +4338,7 @@ $acePath = file_exists('/usr/local/emhttp/plugins/dynamix/javascript/ace/ace.js'
 
         try {
             if (content.trim()) {
-                jsyaml.load(content);
+                loadComposeYaml(content);
             }
             updateValidation(type, content, true);
         } catch (e) {

--- a/tests/unit/ComposeManagerMainSourceTest.php
+++ b/tests/unit/ComposeManagerMainSourceTest.php
@@ -66,4 +66,20 @@ class ComposeManagerMainSourceTest extends TestCase
         $this->assertStringContainsString('var memPair = parseMemUsagePair(parts[2]);', $source);
         $this->assertStringContainsString('memLimitBytes: memPair.limit,', $source);
     }
+
+    public function testComposeCustomTagSchemaSupportIsDeclared(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString("var customTags = ['!override', '!reset', '!merge'];", $source);
+        $this->assertStringContainsString('function hasComposeCustomYamlTag(content)', $source);
+    }
+
+    public function testUnknownTagFallbackIsScopedToComposeTags(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('function stripComposeCustomYamlTags(content)', $source);
+        $this->assertStringContainsString('.replace(/!<(?:override|reset|merge)>/g, \'\')', $source);
+        $this->assertStringContainsString('.replace(/!(?:override|reset|merge)\\b/g, \'\')', $source);
+        $this->assertStringContainsString('if (/unknown tag/i.test(message) && hasComposeCustomYamlTag(input)) {', $source);
+    }
 }

--- a/tests/unit/ComposeManagerMainSourceTest.php
+++ b/tests/unit/ComposeManagerMainSourceTest.php
@@ -71,15 +71,7 @@ class ComposeManagerMainSourceTest extends TestCase
     {
         $source = $this->getPageSource();
         $this->assertStringContainsString("var customTags = ['!override', '!reset', '!merge'];", $source);
-        $this->assertStringContainsString('function hasComposeCustomYamlTag(content)', $source);
+        $this->assertStringContainsString('function buildComposeYamlSchema()', $source);
     }
 
-    public function testUnknownTagFallbackIsScopedToComposeTags(): void
-    {
-        $source = $this->getPageSource();
-        $this->assertStringContainsString('function stripComposeCustomYamlTags(content)', $source);
-        $this->assertStringContainsString('.replace(/!<(?:override|reset|merge)>/g, \'\')', $source);
-        $this->assertStringContainsString('.replace(/!(?:override|reset|merge)\\b/g, \'\')', $source);
-        $this->assertStringContainsString('if (/unknown tag/i.test(message) && hasComposeCustomYamlTag(input)) {', $source);
-    }
 }

--- a/tests/unit/ComposeManagerMainSourceTest.php
+++ b/tests/unit/ComposeManagerMainSourceTest.php
@@ -72,6 +72,15 @@ class ComposeManagerMainSourceTest extends TestCase
         $source = $this->getPageSource();
         $this->assertStringContainsString("var customTags = ['!override', '!reset', '!merge'];", $source);
         $this->assertStringContainsString('function buildComposeYamlSchema()', $source);
+        $this->assertStringContainsString("if (typeof jsyaml !== 'undefined') {", $source);
+        $this->assertStringContainsString("throw new Error('YAML parser is unavailable. Please reload the page and try again.');", $source);
+    }
+
+    public function testLabelSaveBlocksTaggedOverrideRewrite(): void
+    {
+        $source = $this->getPageSource();
+        $this->assertStringContainsString('overrideHasCustomTags: composeYamlContainsCustomTags(overrideData.content || \'\')', $source);
+        $this->assertStringContainsString('WebUI labels cannot be saved because compose.override.yaml uses !override, !reset, or !merge tags.', $source);
     }
 
 }


### PR DESCRIPTION
This pull request enhances Docker Compose YAML parsing in the Compose Manager by adding support for custom YAML tags (`!override`, `!reset`, `!merge`). It introduces a custom schema for `jsyaml` to handle these tags robustly and refactors YAML loading throughout the codebase to use this schema. Additionally, a unit test is added to ensure the custom tag support is present in the source.

**YAML Parsing Improvements:**

* Added `buildComposeYamlSchema` and `loadComposeYaml` functions to define and use a custom `jsyaml` schema supporting the `!override`, `!reset`, and `!merge` tags for all YAML kinds (scalar, sequence, mapping). (`source/compose.manager/include/ComposeManager.php`)
* Refactored all YAML loading (`jsyaml.load`) calls in the codebase to use the new `loadComposeYaml` function, ensuring consistent handling of custom tags. (`source/compose.manager/include/ComposeManager.php`) [[1]](diffhunk://#diff-0ec226ad82016e4a6b25fa42e0821db0ec0d3b18eedd0b7503ba6e6eeaed9d45L2318-R2365) [[2]](diffhunk://#diff-0ec226ad82016e4a6b25fa42e0821db0ec0d3b18eedd0b7503ba6e6eeaed9d45L4088-R4138) [[3]](diffhunk://#diff-0ec226ad82016e4a6b25fa42e0821db0ec0d3b18eedd0b7503ba6e6eeaed9d45L4282-R4329)

**Testing:**

* Added a unit test to verify that the custom tag schema and related functions are present in the generated page source. (`tests/unit/ComposeManagerMainSourceTest.php`)Title: Pull request summary

**What changed**
Short summary of changes and rationale.

**Related issues**
Closes #<issue-number> (if applicable)

**Checklist**
- [x] I have added/updated tests where applicable
- [x] I have updated documentation (docs/, README, or plugin docs)
- [x] Linted/formatted the code
- [x] Verified on Unraid or CI

**Testing notes**
How to test locally (commands, env vars).

**Notes**
For issue #81 - [Bug]: Override Tag Causes Yaml Error