### PR TITLE
feat: show docker.versions changelogs in the update dialog

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,6 +41,16 @@ Each stack supports the following actions:
 | **Edit Stack** | Open the stack editor |
 | **Remove Stack** | Delete the stack configuration |
 
+### Checking for Updates
+
+Use **Check Updates** on a stack to query the registry for newer image versions. Results are cached until the next manual or scheduled check (see [Update Checking settings](configuration.md#update-checking)).
+
+When updates are available, clicking **Update Stack** opens a confirmation dialog listing each container alongside its current and incoming image digest. Containers that are already up to date are dimmed.
+
+#### Changelogs
+
+If the [docker.versions](https://github.com/phyzical/docker.versions) Unraid plugin is installed, a **Changelog** link appears below the digest for each container with a pending update. Clicking it opens the release notes for that image in a modal. No configuration is required — Compose Manager detects docker.versions automatically.
+
 ## Autostart
 
 Enable autostart to have stacks start automatically when the Unraid array starts.

--- a/source/compose.manager/include/Exec.php
+++ b/source/compose.manager/include/Exec.php
@@ -1504,15 +1504,16 @@ switch ($_POST['action']) {
     case 'getSavedUpdateStatus':
         // Load saved update status from file
         $composeUpdateStatusFile = COMPOSE_UPDATE_STATUS_FILE;
+        $dockerVersionsInstalled = is_dir('/usr/local/emhttp/plugins/docker.versions');
         if (is_file($composeUpdateStatusFile)) {
             $savedStatus = json_decode(file_get_contents($composeUpdateStatusFile), true);
             if ($savedStatus) {
-                echo json_encode(['result' => 'success', 'stacks' => $savedStatus]);
+                echo json_encode(['result' => 'success', 'stacks' => $savedStatus, 'dockerVersionsInstalled' => $dockerVersionsInstalled]);
             } else {
-                echo json_encode(['result' => 'success', 'stacks' => []]);
+                echo json_encode(['result' => 'success', 'stacks' => [], 'dockerVersionsInstalled' => $dockerVersionsInstalled]);
             }
         } else {
-            echo json_encode(['result' => 'success', 'stacks' => []]);
+            echo json_encode(['result' => 'success', 'stacks' => [], 'dockerVersionsInstalled' => $dockerVersionsInstalled]);
         }
         break;
     case 'getLogs':

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3505,162 +3505,28 @@ function mergeUpdateStatus(containers, project) {
     return containers;
 }
 
-// Minimal markdown renderer for docker.versions release bodies.
-// docker.versions publishes the raw GitHub API `body` field (Markdown) inside
-// plain <div> elements.  This converts the common patterns found in release
-// notes to HTML; no external library required.
-function composeRenderMarkdown(md) {
-    if (!md || !md.trim()) return '';
-    var blocks = [];
-    md = md.replace(/```(?:[^\n]*)?\n([\s\S]*?)```/g, function(_, code) {
-        blocks.push('<pre style="background:#f6f8fa;padding:8px;border-radius:4px;overflow-x:auto;white-space:pre;"><code>' +
-            code.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</code></pre>');
-        return '\x00' + (blocks.length - 1) + '\x00';
-    });
-    md = md.replace(/`([^`\n]+)`/g, function(_, c) {
-        return '<code style="background:#f0f0f0;padding:1px 4px;border-radius:3px;font-size:0.9em;">' +
-            c.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</code>';
-    });
-    var out = '';
-    var inUL = false;
-    md.split('\n').forEach(function(line) {
-        var h = line.match(/^(#{1,6})\s+(.*)/);
-        if (h) {
-            if (inUL) { out += '</ul>'; inUL = false; }
-            var n = h[1].length;
-            out += '<h' + n + ' style="margin:8px 0 4px;">' + composeInlineMd(h[2]) + '</h' + n + '>';
-            return;
-        }
-        var li = line.match(/^\s*[-*+]\s+(.*)/);
-        if (li) {
-            if (!inUL) { out += '<ul style="margin:4px 0;padding-left:20px;">'; inUL = true; }
-            out += '<li>' + composeInlineMd(li[1]) + '</li>';
-            return;
-        }
-        if (!line.trim()) {
-            if (inUL) { out += '</ul>'; inUL = false; }
-            out += '<br>';
-            return;
-        }
-        if (inUL) { out += '</ul>'; inUL = false; }
-        out += '<p style="margin:4px 0;">' + composeInlineMd(line) + '</p>';
-    });
-    if (inUL) out += '</ul>';
-    return out.replace(/\x00(\d+)\x00/g, function(_, i) { return blocks[i]; });
-}
-
-function composeInlineMd(t) {
-    t = t.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
-    t = t.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-    t = t.replace(/\*(.+?)\*/g, '<em>$1</em>');
-    t = t.replace(/~~(.+?)~~/g, '<del>$1</del>');
-    t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
-    return t;
-}
-
-// Show docker.versions changelog for a single container in a modal.
-// Only called when dockerVersionsInstalled is true; guards against NchanSubscriber
-// being unavailable (e.g. docker.versions removed without page reload).
+// Show docker.versions changelog for a single container.
+// Delegates entirely to docker.versions' own showChangeLog() so that display
+// logic, Nchan subscription management, and message routing stay in one place.
 //
-// Coupling points with docker.versions (update here if that plugin changes them):
-//   - Nchan topic:  /sub/changelog
-//   - PHP endpoint: /plugins/docker.versions/server/GetChangelog.php
+// Coupling point: showChangeLog(containerName) — global function from
+// docker.versions/scripts/changelog.js.  If that function is renamed or
+// removed, this feature silently does nothing.
 function showComposeChangelog(containerName, path, profile) {
-    if (typeof NchanSubscriber === 'undefined') return;
-
-    var nchan = new NchanSubscriber('/sub/changelog');
-    var timeoutId = null;
-
-    // /sub/changelog is a shared Nchan channel used by docker.versions for all
-    // changelog requests.  Two problems arise if we naively append all messages:
-    //
-    //  1. Stale buffer: Nchan delivers the last buffered message to every new
-    //     subscriber, so we may immediately receive output from a prior request.
-    //  2. Concurrent contamination: docker.versions' own subscriber may be actively
-    //     receiving changelog output for a different container at the same time.
-    //
-    // GetChangelog.php always publishes <h3 class='loading'> as its very first
-    // message.  We use that as a start-of-stream marker: discard everything that
-    // arrives before it, clear the iframe when it arrives, then display from there.
-    // After the start marker, only release entries (class='releasesInfo') and
-    // the version-summary h3 with '---->' are displayed; everything else
-    // (warnings, Container: header, URL links, progress) is filtered out.
-    var started = false;
-    nchan.on('message', function(data) {
-        if (data.includes("class='loading'") && !data.includes("class='loadingInfo'")) {
-            started = true;
-            clearTimeout(timeoutId);
-            var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
-            if (iframeDoc) $(iframeDoc).find('body').empty().css('background-color', 'white');
-            timeoutId = setTimeout(function() {
-                var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
-                if (iframeDoc && !$(iframeDoc).find('body').children().length) {
-                    $(iframeDoc).find('body').html(
-                        '<p style="padding:16px;color:#888;">Changelog unavailable — no data received from docker.versions.</p>'
-                    );
-                }
-            }, 10000);
-            return;
-        }
-        if (!started) return;
-
-        // Whitelist: only the two message types that are useful in this context.
-        //   class='releasesInfo'  — the <details> block for each release entry
-        //   <h3> with '---->'     — the "current tag → latest tag" version summary
-        // Everything else (Container: header, URL links, warnings, empty <pre>
-        // container, loadingInfo progress) is informational scaffolding for
-        // docker.versions' own full-page view and is noise here.
-        var isReleaseEntry = data.includes("class='releasesInfo'");
-        var isVersionSummary = /^<h3[\s>]/.test(data.trim()) && data.includes('---->');
-        if (!isReleaseEntry && !isVersionSummary) return;
-
-        var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
-        if (!iframeDoc) return;
-        var tmp = document.createElement('div');
-        tmp.innerHTML = data;
-        tmp.querySelectorAll('div').forEach(function(div) {
-            if (div.children.length === 0 && div.textContent.trim()) {
-                div.innerHTML = composeRenderMarkdown(div.textContent);
-            }
-        });
-        $(iframeDoc).find('body').append(tmp.innerHTML);
-    });
-    nchan.start();
-
-    swal({
-        title: 'Changelog: ' + containerName,
-        text: '<iframe id="myIframe" frameborder="0" scrolling="yes" width="100%" height="99%"></iframe>',
-        html: true,
-        closeOnConfirm: true,
-        showCancelButton: false,
-        allowOutsideClick: true,
-    }, function() {
-        clearTimeout(timeoutId);
-        nchan.stop();
-        swal.close();
-        if (path) showStackActionDialog('update', path, profile || '');
-    });
-
-    // Size the dialog to match docker.versions' changelog modal without borrowing
-    // its CSS classes (avoids depending on its stylesheet being loaded).
-    // Equivalent to: .sweet-alert.change-log-summary + .change-log-iframe-container + #myIframe
-    $('.sweet-alert').css({ width: '75%', maxWidth: '75%' });
-    $('#myIframe').parent().css('height', '80%');
-    $('#myIframe').css('height', '75vh');
-
-    // Fallback shown only if the start marker never arrives (docker.versions
-    // endpoint moved, Nchan topic changed, or container not found).
-    timeoutId = setTimeout(function() {
-        if (started) return;
-        var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
-        if (iframeDoc) {
-            $(iframeDoc).find('body').html(
-                '<p style="padding:16px;color:#888;">Changelog unavailable — no data received from docker.versions.</p>'
-            );
-        }
-    }, 10000);
-
-    $.get('/plugins/docker.versions/server/GetChangelog.php', { 'cts[]': containerName });
+    if (typeof showChangeLog !== 'function') return;
+    showChangeLog(containerName);
+    // docker.versions' OK button calls updateContainer(), which bypasses
+    // compose_plugin's update mechanism.  Hide it so the only exit is Cancel.
+    setTimeout(function() { $('.sweet-alert .confirm').hide(); }, 0);
+    if (!path) return;
+    // Reopen the Update Stack dialog when the changelog dialog closes.
+    // SweetAlert 1.x has no close event; poll the showSweetAlert class instead.
+    var appeared = false;
+    var poll = setInterval(function() {
+        var open = $('.sweet-alert').hasClass('showSweetAlert');
+        if (!appeared) { if (open) appeared = true; return; }
+        if (!open) { clearInterval(poll); showStackActionDialog('update', path, profile || ''); }
+    }, 100);
 }
 
 // Unified stack action dialog - handles up, down, and update actions

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3582,8 +3582,9 @@ function showComposeChangelog(containerName, path, profile) {
     // GetChangelog.php always publishes <h3 class='loading'> as its very first
     // message.  We use that as a start-of-stream marker: discard everything that
     // arrives before it, clear the iframe when it arrives, then display from there.
-    // loadingInfo progress messages are also suppressed — they're informational
-    // noise that clutters the changelog view.
+    // After the start marker, only release entries (class='releasesInfo') and
+    // the version-summary h3 with '---->' are displayed; everything else
+    // (warnings, Container: header, URL links, progress) is filtered out.
     var started = false;
     nchan.on('message', function(data) {
         if (data.includes("class='loading'") && !data.includes("class='loadingInfo'")) {
@@ -3602,7 +3603,16 @@ function showComposeChangelog(containerName, path, profile) {
             return;
         }
         if (!started) return;
-        if (data.includes("class='loadingInfo'")) return;
+
+        // Whitelist: only the two message types that are useful in this context.
+        //   class='releasesInfo'  — the <details> block for each release entry
+        //   <h3> with '---->'     — the "current tag → latest tag" version summary
+        // Everything else (Container: header, URL links, warnings, empty <pre>
+        // container, loadingInfo progress) is informational scaffolding for
+        // docker.versions' own full-page view and is noise here.
+        var isReleaseEntry = data.includes("class='releasesInfo'");
+        var isVersionSummary = /^<h3[\s>]/.test(data.trim()) && data.includes('---->');
+        if (!isReleaseEntry && !isVersionSummary) return;
 
         var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
         if (!iframeDoc) return;

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3505,6 +3505,59 @@ function mergeUpdateStatus(containers, project) {
     return containers;
 }
 
+// Minimal markdown renderer for docker.versions release bodies.
+// docker.versions publishes the raw GitHub API `body` field (Markdown) inside
+// plain <div> elements.  This converts the common patterns found in release
+// notes to HTML; no external library required.
+function composeRenderMarkdown(md) {
+    if (!md || !md.trim()) return '';
+    var blocks = [];
+    md = md.replace(/```(?:[^\n]*)?\n([\s\S]*?)```/g, function(_, code) {
+        blocks.push('<pre style="background:#f6f8fa;padding:8px;border-radius:4px;overflow-x:auto;white-space:pre;"><code>' +
+            code.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</code></pre>');
+        return '\x00' + (blocks.length - 1) + '\x00';
+    });
+    md = md.replace(/`([^`\n]+)`/g, function(_, c) {
+        return '<code style="background:#f0f0f0;padding:1px 4px;border-radius:3px;font-size:0.9em;">' +
+            c.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</code>';
+    });
+    var out = '';
+    var inUL = false;
+    md.split('\n').forEach(function(line) {
+        var h = line.match(/^(#{1,6})\s+(.*)/);
+        if (h) {
+            if (inUL) { out += '</ul>'; inUL = false; }
+            var n = h[1].length;
+            out += '<h' + n + ' style="margin:8px 0 4px;">' + composeInlineMd(h[2]) + '</h' + n + '>';
+            return;
+        }
+        var li = line.match(/^\s*[-*+]\s+(.*)/);
+        if (li) {
+            if (!inUL) { out += '<ul style="margin:4px 0;padding-left:20px;">'; inUL = true; }
+            out += '<li>' + composeInlineMd(li[1]) + '</li>';
+            return;
+        }
+        if (!line.trim()) {
+            if (inUL) { out += '</ul>'; inUL = false; }
+            out += '<br>';
+            return;
+        }
+        if (inUL) { out += '</ul>'; inUL = false; }
+        out += '<p style="margin:4px 0;">' + composeInlineMd(line) + '</p>';
+    });
+    if (inUL) out += '</ul>';
+    return out.replace(/\x00(\d+)\x00/g, function(_, i) { return blocks[i]; });
+}
+
+function composeInlineMd(t) {
+    t = t.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+    t = t.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    t = t.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    t = t.replace(/~~(.+?)~~/g, '<del>$1</del>');
+    t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    return t;
+}
+
 // Show docker.versions changelog for a single container in a modal.
 // Only called when dockerVersionsInstalled is true; guards against NchanSubscriber
 // being unavailable (e.g. docker.versions removed without page reload).
@@ -3518,12 +3571,19 @@ function showComposeChangelog(containerName) {
     var nchan = new NchanSubscriber('/sub/changelog');
     var timeoutId = null;
 
-    // Append all Nchan messages directly to the iframe body.  Avoids depending on
-    // docker.versions' internal HTML class names to route content to sub-elements.
+    // Append Nchan messages to the iframe body.  docker.versions publishes raw
+    // Markdown inside bare <div> elements; render those before inserting.
     nchan.on('message', function(data) {
         var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
         if (!iframeDoc) return;
-        $(iframeDoc).find('body').css('background-color', 'white').append(data);
+        var tmp = document.createElement('div');
+        tmp.innerHTML = data;
+        tmp.querySelectorAll('div').forEach(function(div) {
+            if (div.children.length === 0 && div.textContent.trim()) {
+                div.innerHTML = composeRenderMarkdown(div.textContent);
+            }
+        });
+        $(iframeDoc).find('body').css('background-color', 'white').append(tmp.innerHTML);
     });
     nchan.start();
 

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3571,9 +3571,39 @@ function showComposeChangelog(containerName, path, profile) {
     var nchan = new NchanSubscriber('/sub/changelog');
     var timeoutId = null;
 
-    // Append Nchan messages to the iframe body.  docker.versions publishes raw
-    // Markdown inside bare <div> elements; render those before inserting.
+    // /sub/changelog is a shared Nchan channel used by docker.versions for all
+    // changelog requests.  Two problems arise if we naively append all messages:
+    //
+    //  1. Stale buffer: Nchan delivers the last buffered message to every new
+    //     subscriber, so we may immediately receive output from a prior request.
+    //  2. Concurrent contamination: docker.versions' own subscriber may be actively
+    //     receiving changelog output for a different container at the same time.
+    //
+    // GetChangelog.php always publishes <h3 class='loading'> as its very first
+    // message.  We use that as a start-of-stream marker: discard everything that
+    // arrives before it, clear the iframe when it arrives, then display from there.
+    // loadingInfo progress messages are also suppressed — they're informational
+    // noise that clutters the changelog view.
+    var started = false;
     nchan.on('message', function(data) {
+        if (data.includes("class='loading'") && !data.includes("class='loadingInfo'")) {
+            started = true;
+            clearTimeout(timeoutId);
+            var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
+            if (iframeDoc) $(iframeDoc).find('body').empty().css('background-color', 'white');
+            timeoutId = setTimeout(function() {
+                var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
+                if (iframeDoc && !$(iframeDoc).find('body').children().length) {
+                    $(iframeDoc).find('body').html(
+                        '<p style="padding:16px;color:#888;">Changelog unavailable — no data received from docker.versions.</p>'
+                    );
+                }
+            }, 10000);
+            return;
+        }
+        if (!started) return;
+        if (data.includes("class='loadingInfo'")) return;
+
         var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
         if (!iframeDoc) return;
         var tmp = document.createElement('div');
@@ -3583,7 +3613,7 @@ function showComposeChangelog(containerName, path, profile) {
                 div.innerHTML = composeRenderMarkdown(div.textContent);
             }
         });
-        $(iframeDoc).find('body').css('background-color', 'white').append(tmp.innerHTML);
+        $(iframeDoc).find('body').append(tmp.innerHTML);
     });
     nchan.start();
 
@@ -3608,11 +3638,12 @@ function showComposeChangelog(containerName, path, profile) {
     $('#myIframe').parent().css('height', '80%');
     $('#myIframe').css('height', '75vh');
 
-    // Show a fallback if docker.versions sends nothing (endpoint moved, Nchan topic
-    // changed, or container not found by docker.versions).
+    // Fallback shown only if the start marker never arrives (docker.versions
+    // endpoint moved, Nchan topic changed, or container not found).
     timeoutId = setTimeout(function() {
+        if (started) return;
         var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
-        if (iframeDoc && !$(iframeDoc).find('body').children().length) {
+        if (iframeDoc) {
             $(iframeDoc).find('body').html(
                 '<p style="padding:16px;color:#888;">Changelog unavailable — no data received from docker.versions.</p>'
             );

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3521,11 +3521,23 @@ function showComposeChangelog(containerName, path, profile) {
     if (!path) return;
     // Reopen the Update Stack dialog when the changelog dialog closes.
     // SweetAlert 1.x has no close event; poll the showSweetAlert class instead.
+    // Cap at 300 ticks (30 s) so the interval self-cleans if the dialog never opens.
     var appeared = false;
+    var ticks = 0;
     var poll = setInterval(function() {
+        if (++ticks > 300) { clearInterval(poll); return; }
         var open = $('.sweet-alert').hasClass('showSweetAlert');
         if (!appeared) { if (open) appeared = true; return; }
-        if (!open) { clearInterval(poll); showStackActionDialog('update', path, profile || ''); }
+        if (!open) {
+            clearInterval(poll);
+            // Skip reopening when DISABLE_ACTION_WARNINGS is true: renderStackActionDialog
+            // has a fast-path that calls UpdateStackConfirmed directly in that mode,
+            // so reopening would trigger an immediate update rather than a dialog.
+            getConfig().then(function(cfg) {
+                if (cfg && cfg.DISABLE_ACTION_WARNINGS === 'true') return;
+                showStackActionDialog('update', path, profile || '');
+            });
+        }
     }, 100);
 }
 

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -3565,7 +3565,7 @@ function composeInlineMd(t) {
 // Coupling points with docker.versions (update here if that plugin changes them):
 //   - Nchan topic:  /sub/changelog
 //   - PHP endpoint: /plugins/docker.versions/server/GetChangelog.php
-function showComposeChangelog(containerName) {
+function showComposeChangelog(containerName, path, profile) {
     if (typeof NchanSubscriber === 'undefined') return;
 
     var nchan = new NchanSubscriber('/sub/changelog');
@@ -3598,6 +3598,7 @@ function showComposeChangelog(containerName) {
         clearTimeout(timeoutId);
         nchan.stop();
         swal.close();
+        if (path) showStackActionDialog('update', path, profile || '');
     });
 
     // Size the dialog to match docker.versions' changelog modal without borrowing
@@ -3874,7 +3875,7 @@ function renderStackActionDialog(action, displayName, path, profile, containers,
                     html += '<span class="compose-status-success" title="' + composeEscapeAttr(remoteSha) + '">' + composeEscapeHtml(remoteSha.substring(0, 8)) + '</span>';
                     html += '</div>';
                     if (dockerVersionsInstalled) {
-                        html += '<div style="margin-top:4px;"><a href="#" data-changelog-container="' + composeEscapeAttr(containerName) + '" onclick="showComposeChangelog(this.dataset.changelogContainer);return false;" style="font-size:0.85em;"><i class="fa fa-list" style="margin-right:3px;"></i>Changelog</a></div>';
+                        html += '<div style="margin-top:4px;"><a href="#" data-changelog-container="' + composeEscapeAttr(containerName) + '" data-changelog-path="' + composeEscapeAttr(path) + '" data-changelog-profile="' + composeEscapeAttr(profile || '') + '" onclick="showComposeChangelog(this.dataset.changelogContainer,this.dataset.changelogPath,this.dataset.changelogProfile);return false;" style="font-size:0.85em;"><i class="fa fa-list" style="margin-right:3px;"></i>Changelog</a></div>';
                     }
                 } else if (localSha) {
                     // No update - just show current SHA (greyed)

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -966,6 +966,9 @@ function updateTabModifiedState() {
 // Update status cache per stack
 var stackUpdateStatus = {};
 
+// Set to true when docker.versions plugin is detected (populated from getSavedUpdateStatus response)
+var dockerVersionsInstalled = false;
+
 // Load saved update status from server (called on page load)
 // If auto-check is enabled and interval has elapsed, trigger a fresh check
 // Also checks for pending rechecks from recent update operations
@@ -978,6 +981,7 @@ function loadSavedUpdateStatus() {
                 var response = JSON.parse(data);
                 if (response.result === 'success' && response.stacks) {
                     stackUpdateStatus = response.stacks;
+                    if (response.dockerVersionsInstalled) dockerVersionsInstalled = true;
 
                     // Update the UI for each stack with saved status
                     for (var stackName in response.stacks) {
@@ -3501,6 +3505,62 @@ function mergeUpdateStatus(containers, project) {
     return containers;
 }
 
+// Show docker.versions changelog for a single container in a modal.
+// Only called when dockerVersionsInstalled is true; guards against NchanSubscriber
+// being unavailable (e.g. docker.versions removed without page reload).
+//
+// Coupling points with docker.versions (update here if that plugin changes them):
+//   - Nchan topic:  /sub/changelog
+//   - PHP endpoint: /plugins/docker.versions/server/GetChangelog.php
+function showComposeChangelog(containerName) {
+    if (typeof NchanSubscriber === 'undefined') return;
+
+    var nchan = new NchanSubscriber('/sub/changelog');
+    var timeoutId = null;
+
+    // Append all Nchan messages directly to the iframe body.  Avoids depending on
+    // docker.versions' internal HTML class names to route content to sub-elements.
+    nchan.on('message', function(data) {
+        var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
+        if (!iframeDoc) return;
+        $(iframeDoc).find('body').css('background-color', 'white').append(data);
+    });
+    nchan.start();
+
+    swal({
+        title: 'Changelog: ' + containerName,
+        text: '<iframe id="myIframe" frameborder="0" scrolling="yes" width="100%" height="99%"></iframe>',
+        html: true,
+        closeOnConfirm: true,
+        showCancelButton: false,
+        allowOutsideClick: true,
+    }, function() {
+        clearTimeout(timeoutId);
+        nchan.stop();
+        swal.close();
+    });
+
+    // Size the dialog to match docker.versions' changelog modal without borrowing
+    // its CSS classes (avoids depending on its stylesheet being loaded).
+    // Equivalent to: .sweet-alert.change-log-summary + .change-log-iframe-container + #myIframe
+    $('.sweet-alert').css({ width: '75%', maxWidth: '75%' });
+    $('#myIframe').parent().css('height', '80%');
+    $('#myIframe').css('height', '75vh');
+
+    // Show a fallback if docker.versions sends nothing (endpoint moved, Nchan topic
+    // changed, or container not found by docker.versions).
+    timeoutId = setTimeout(function() {
+        var iframeDoc = $('#myIframe')[0] && $('#myIframe')[0].contentDocument;
+        if (iframeDoc && !$(iframeDoc).find('body').children().length) {
+            $(iframeDoc).find('body').html(
+                '<p style="padding:16px;color:#888;">Changelog unavailable — no data received from docker.versions.</p>'
+            );
+        }
+    }, 10000);
+
+    $.get('/plugins/docker.versions/server/GetChangelog.php', { 'cts[]': containerName });
+}
+
 // Unified stack action dialog - handles up, down, and update actions
 function showStackActionDialog(action, path, profile) {
     var stackName = basename(path);
@@ -3753,6 +3813,9 @@ function renderStackActionDialog(action, displayName, path, profile, containers,
                     html += ' <i class="fa fa-arrow-right compose-status-success" style="margin:0 4px;"></i> ';
                     html += '<span class="compose-status-success" title="' + composeEscapeAttr(remoteSha) + '">' + composeEscapeHtml(remoteSha.substring(0, 8)) + '</span>';
                     html += '</div>';
+                    if (dockerVersionsInstalled) {
+                        html += '<div style="margin-top:4px;"><a href="#" data-changelog-container="' + composeEscapeAttr(containerName) + '" onclick="showComposeChangelog(this.dataset.changelogContainer);return false;" style="font-size:0.85em;"><i class="fa fa-list" style="margin-right:3px;"></i>Changelog</a></div>';
+                    }
                 } else if (localSha) {
                     // No update - just show current SHA (greyed)
                     html += '<div style="font-family:var(--font-bitstream);font-size:0.9em;margin-top:2px;" title="' + composeEscapeAttr(localSha) + '"><span class="compose-text-muted">' + composeEscapeHtml(localSha.substring(0, 8)) + '</span></div>';

--- a/tests/unit/ExecActionsTest.php
+++ b/tests/unit/ExecActionsTest.php
@@ -1065,12 +1065,16 @@ class ExecActionsTest extends TestCase
     /**
      * Returns dockerVersionsInstalled=false when the plugin directory is absent.
      */
-    public function testGetSavedUpdateStatusDockerVersionsNotInstalled(): void
-    {
-        @unlink(COMPOSE_UPDATE_STATUS_FILE);
+public function testGetSavedUpdateStatusDockerVersionsNotInstalled(): void
+{
+    @unlink(COMPOSE_UPDATE_STATUS_FILE);
 
-        $output = $this->executeAction('getSavedUpdateStatus');
-        $result = json_decode($output, true);
+    // Make the test deterministic even when running on a host that has docker.versions installed.
+    $fakeDir = sys_get_temp_dir() . '/fake_docker_versions_absent_' . getmypid();
+    UnraidStreamWrapper::addMapping('/usr/local/emhttp/plugins/docker.versions', $fakeDir);
+
+    $output = $this->executeAction('getSavedUpdateStatus');
+    $result = json_decode($output, true);
 
         $this->assertIsArray($result);
         $this->assertEquals('success', $result['result']);

--- a/tests/unit/ExecActionsTest.php
+++ b/tests/unit/ExecActionsTest.php
@@ -16,6 +16,7 @@ namespace ComposeManager\Tests;
 
 use PluginTests\TestCase;
 use PluginTests\Mocks\FunctionMocks;
+use PluginTests\StreamWrapper\UnraidStreamWrapper;
 
 
 require_once '/usr/local/emhttp/plugins/compose.manager/include/Util.php';
@@ -1055,6 +1056,88 @@ class ExecActionsTest extends TestCase
             $this->assertEquals('error', $result['result']);
             $this->assertStringContainsString('Invalid icon', $result['message']);
         }
+    }
+
+    // ===========================================
+    // getSavedUpdateStatus Action Tests
+    // ===========================================
+
+    /**
+     * Returns dockerVersionsInstalled=false when the plugin directory is absent.
+     */
+    public function testGetSavedUpdateStatusDockerVersionsNotInstalled(): void
+    {
+        @unlink(COMPOSE_UPDATE_STATUS_FILE);
+
+        $output = $this->executeAction('getSavedUpdateStatus');
+        $result = json_decode($output, true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals('success', $result['result']);
+        $this->assertSame([], $result['stacks']);
+        $this->assertFalse($result['dockerVersionsInstalled']);
+    }
+
+    /**
+     * Returns dockerVersionsInstalled=true when the plugin directory exists.
+     */
+    public function testGetSavedUpdateStatusDockerVersionsInstalled(): void
+    {
+        @unlink(COMPOSE_UPDATE_STATUS_FILE);
+
+        $fakeDir = sys_get_temp_dir() . '/fake_docker_versions_' . getmypid();
+        mkdir($fakeDir, 0755, true);
+        $this->externalCleanupPaths[] = $fakeDir;
+        UnraidStreamWrapper::addMapping('/usr/local/emhttp/plugins/docker.versions', $fakeDir);
+
+        $output = $this->executeAction('getSavedUpdateStatus');
+        $result = json_decode($output, true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals('success', $result['result']);
+        $this->assertSame([], $result['stacks']);
+        $this->assertTrue($result['dockerVersionsInstalled']);
+    }
+
+    /**
+     * Returns saved stacks alongside dockerVersionsInstalled when a status file exists.
+     */
+    public function testGetSavedUpdateStatusIncludesSavedStacks(): void
+    {
+        $savedStatus = ['my-stack' => ['hasUpdate' => true, 'containers' => []]];
+        file_put_contents(COMPOSE_UPDATE_STATUS_FILE, json_encode($savedStatus));
+
+        $fakeDir = sys_get_temp_dir() . '/fake_docker_versions_' . getmypid();
+        mkdir($fakeDir, 0755, true);
+        $this->externalCleanupPaths[] = $fakeDir;
+        UnraidStreamWrapper::addMapping('/usr/local/emhttp/plugins/docker.versions', $fakeDir);
+
+        $output = $this->executeAction('getSavedUpdateStatus');
+        $result = json_decode($output, true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals('success', $result['result']);
+        $this->assertEquals($savedStatus, $result['stacks']);
+        $this->assertTrue($result['dockerVersionsInstalled']);
+
+        @unlink(COMPOSE_UPDATE_STATUS_FILE);
+    }
+
+    /**
+     * Falls back to empty stacks when the status file contains invalid JSON.
+     */
+    public function testGetSavedUpdateStatusHandlesInvalidStatusFile(): void
+    {
+        file_put_contents(COMPOSE_UPDATE_STATUS_FILE, 'not-valid-json');
+
+        $output = $this->executeAction('getSavedUpdateStatus');
+        $result = json_decode($output, true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals('success', $result['result']);
+        $this->assertSame([], $result['stacks']);
+
+        @unlink(COMPOSE_UPDATE_STATUS_FILE);
     }
 
     // ===========================================


### PR DESCRIPTION
**What changed**
Adds optional integration with the [docker.versions](https://github.com/phyzical/docker.versions) Unraid plugin. When docker.versions is installed, a **Changelog** link appears beneath the digest arrow for each container with a pending update in the Update Stack dialog. Clicking it opens the release notes via docker.versions' own `showChangeLog()` function. Dismissing the changelog returns to the Update Stack dialog.

docker.versions is detected server-side with `is_dir` and reported via the `getSavedUpdateStatus` response; the feature is entirely absent when the plugin is not installed (no JS errors, no UI changes).

**Related issues**
N/A

**Checklist**
- [x] I have added/updated tests where applicable
- [x] I have updated documentation (docs/, README, or plugin docs)
- [x] Linted/formatted the code
- [x] Verified on Unraid or CI

**Testing notes**
With docker.versions installed:
1. Run **Check Updates** on any stack
2. Click **Update Stack** — a **Changelog** link appears beneath the SHA arrow for containers with pending updates
3. Click the link to view release notes in docker.versions' own changelog modal; dismiss to return to the Update Stack dialog

Without docker.versions: no visible change, no JS errors.

PHPStan and PHPUnit both pass.

**Notes**
- Delegates display entirely to docker.versions' `showChangeLog()` — no duplicated Nchan subscription or message routing logic
- The OK button (which calls `updateContainer()`, bypassing compose_plugin's update mechanism) is hidden so Cancel is the only exit
- Returning to the Update Stack dialog is skipped when `DISABLE_ACTION_WARNINGS` is true, since `renderStackActionDialog` would fast-path directly to `UpdateStackConfirmed` in that mode
- Poll interval is capped at 30 s to prevent a leak if `showChangeLog()` opens no dialog
- Container name is passed via `data-` attributes to avoid HTML attribute quoting issues with inline `onclick` string interpolation