### PR TITLE
Fix dropdown z-index on docker page when clicking on stack icon

### DIFF
--- a/source/compose.manager/include/ComposeManager.php
+++ b/source/compose.manager/include/ComposeManager.php
@@ -236,10 +236,11 @@ if ($cpuCount <= 0) {
         z-index: 100 !important;
     }
 
-    /* Keep long context menus visible above fixed bottom UI bars */
+    /* Keep context menus above the fixed footer (z-index must out-rank the
+       .dropdown-menu !important rule above); the scroll spacer appended in
+       fixContextDropdownOverflow() keeps them reachable (unraid/webgui#2639) */
     .dropdown-context:not(.dropdown-context-sub) {
-        max-height: calc(100vh - 72px);
-        overflow-y: auto;
+        z-index: 10001 !important;
     }
 
     /* CPU & Memory load display (matches Docker manager usage-disk style) */

--- a/source/compose.manager/javascript/composeManagerMain.js
+++ b/source/compose.manager/javascript/composeManagerMain.js
@@ -6218,6 +6218,13 @@ function updateParentStackFromContainers(stackId, project) {
 }
 
 // Attach context menu to container icon (like Docker tab's addDockerContainerContext)
+// Keep a context dropdown above the footer and extend the scrollable area so it stays reachable
+// (same fix as unraid/webgui#2639)
+function fixContextDropdownOverflow(elementId) {
+    $('#dropdown-' + elementId).css('z-index', 10001)
+        .append('<li class="compose-dropdown-spacer" aria-hidden="true" style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
+}
+
 function addComposeContainerContext(elementId) {
     var $el = $('#' + elementId);
     var containerName = $el.data('name');
@@ -6348,6 +6355,7 @@ function addComposeContainerContext(elementId) {
     // Ensure stale menu bindings don't persist across state transitions
     $el.off('contextmenu');
     context.attach('#' + elementId, opts);
+    fixContextDropdownOverflow(elementId);
 }
 
 function containerAction(containerName, action, stackId) {
@@ -6828,6 +6836,7 @@ function addComposeStackContext(elementId) {
 
     context.destroy('#' + elementId);
     context.attach('#' + elementId, opts);
+    fixContextDropdownOverflow(elementId);
 }
 
 // Event delegation for docker-style container actions


### PR DESCRIPTION
Basically copy of the fix for the unraid webui docker page i made here https://github.com/unraid/webgui/pull/2639 applied to the compose page.

Screenshots
Before:
<img width="866" height="301" alt="grafik" src="https://github.com/user-attachments/assets/c135446a-b2f0-443f-b52c-1d6bc8befeda" />
After:
<img width="885" height="342" alt="grafik" src="https://github.com/user-attachments/assets/17edba63-8381-41b5-b391-c031a51e3918" />
